### PR TITLE
Support default styles in PDF adapter

### DIFF
--- a/packages/adapters/pdf/src/pdf.adapter.ts
+++ b/packages/adapters/pdf/src/pdf.adapter.ts
@@ -27,15 +27,17 @@ function isHtml2PdfBuilder(obj: unknown): obj is Html2PdfBuilder {
 
 export class PDFAdapter implements IDocumentConverter {
   private docxAdapter: DocxAdapter;
+  private _defaultStyles: IConverterDependencies['defaultStyles'] = {};
 
   constructor(dependencies: IConverterDependencies) {
     this.docxAdapter = new DocxAdapter(dependencies);
+    this._defaultStyles = { ...(dependencies.defaultStyles ?? {}) };
   }
 
   async convert(elements: DocumentElement[]): Promise<Buffer | Blob> {
     try {
       // Step 1: Convert to DOCX using the existing DocxAdapter
-      const htmlString = toHtml(elements);
+      const htmlString = toHtml(elements, this._defaultStyles);
       if (typeof window !== 'undefined') {
         // Browser: feed HTML straight to html2pdf
         return await this.convertHtmlInBrowser(htmlString);

--- a/packages/core/__tests__/html.serializer.test.ts
+++ b/packages/core/__tests__/html.serializer.test.ts
@@ -2,6 +2,7 @@ import { Parser } from '../src/parser';
 import { JSDOMParser } from './utils/parser.helper';
 import { toHtml } from '../src/utils/html.serializer';
 import { minifyMiddleware } from 'html-to-document-core';
+import { DocumentElement } from '../src/types';
 
 describe('html.serializer', () => {
   let parser: Parser;
@@ -292,6 +293,20 @@ describe('html.serializer', () => {
     // 2) check that other elements (e.g. <h1>) remain unchanged
     expect(transformed).toContain(
       '<h1 style="text-align: center; color: darkblue;">Complex Document Test</h1>'
+    );
+  });
+
+  it('applies default styles when serializing', () => {
+    const elements: DocumentElement[] = [
+      { type: 'paragraph', text: 'Hello', styles: {}, attributes: {} },
+    ];
+
+    const html = toHtml(elements, {
+      paragraph: { color: 'red', fontSize: '12px' },
+    });
+
+    expect(html).toContain(
+      '<p style="color: red; font-size: 12px;">Hello</p>'
     );
   });
 });


### PR DESCRIPTION
## Summary
- allow `toHtml()` to merge default styles
- pass PDF adapter default styles to `toHtml`
- cover default style handling in `html.serializer` tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684096a20254832381bfa541302758cd