### PR TITLE
Improve PDF image layout

### DIFF
--- a/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
+++ b/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
@@ -1,5 +1,6 @@
 import { PDFAdapter } from '../src/pdf.adapter';
 import { DocumentElement, StyleMapper } from 'html-to-document-core';
+import { JSDOM } from 'jsdom';
 import { jest } from '@jest/globals';
 
 // Mock the libreoffice-convert module
@@ -177,6 +178,30 @@ describe('PDFAdapter', () => {
 
       expect(result).toEqual(mockPdfBuffer);
       expect(isPdf(result as Buffer)).toBe(true);
+    });
+  });
+
+  describe('insertPageBreaks', () => {
+    beforeAll(() => {
+      const dom = new JSDOM('<!DOCTYPE html>');
+      (global as any).DOMParser = dom.window.DOMParser;
+      (global as any).NodeFilter = dom.window.NodeFilter;
+    });
+
+    it('should not insert a page break when image fits on current page', () => {
+      const input =
+        '<p>Intro</p><img src="a" height="300"><p>after</p>';
+      const result = (adapter as any).insertPageBreaks(input);
+      expect(result).not.toContain('html2pdf__page-break');
+    });
+
+    it('should insert a page break when image exceeds remaining space', () => {
+      const longText = Array(50)
+        .fill('<p>Line</p>')
+        .join('');
+      const input = `${longText}<img src="a" height="100">`;
+      const result = (adapter as any).insertPageBreaks(input);
+      expect(result).toContain('html2pdf__page-break');
     });
   });
 

--- a/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
+++ b/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
@@ -186,21 +186,32 @@ describe('PDFAdapter', () => {
       const dom = new JSDOM('<!DOCTYPE html>');
       (global as any).DOMParser = dom.window.DOMParser;
       (global as any).NodeFilter = dom.window.NodeFilter;
+      (global as any).Image = class {
+        onload: (() => void) | null = null;
+        naturalHeight = 400;
+        set src(_s: string) {
+          if (this.onload) this.onload();
+        }
+      };
     });
 
-    it('should not insert a page break when image fits on current page', () => {
-      const input =
-        '<p>Intro</p><img src="a" height="300"><p>after</p>';
-      const result = (adapter as any).insertPageBreaks(input);
+    it('should not insert a page break when image fits on current page', async () => {
+      const input = '<p>Intro</p><img src="a" height="300"><p>after</p>';
+      const result = await (adapter as any).insertPageBreaks(input);
       expect(result).not.toContain('html2pdf__page-break');
     });
 
-    it('should insert a page break when image exceeds remaining space', () => {
-      const longText = Array(50)
-        .fill('<p>Line</p>')
-        .join('');
+    it('should insert a page break when image exceeds remaining space', async () => {
+      const longText = Array(50).fill('<p>Line</p>').join('');
       const input = `${longText}<img src="a" height="100">`;
-      const result = (adapter as any).insertPageBreaks(input);
+      const result = await (adapter as any).insertPageBreaks(input);
+      expect(result).toContain('html2pdf__page-break');
+    });
+
+    it('should use natural height when no attribute provided', async () => {
+      const longText = Array(50).fill('<p>Line</p>').join('');
+      const input = `${longText}<img src="img.png">`;
+      const result = await (adapter as any).insertPageBreaks(input);
       expect(result).toContain('html2pdf__page-break');
     });
   });


### PR DESCRIPTION
## Summary
- adjust PDF adapter to calculate remaining space when adding images
- add tests for page break logic in pdf adapter

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68409c2c57288323ba00ddac77e4b574