### PR TITLE
Fix PDF element overflow handling

### DIFF
--- a/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
+++ b/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
@@ -214,6 +214,14 @@ describe('PDFAdapter', () => {
       const result = await (adapter as any).insertPageBreaks(input);
       expect(result).toContain('html2pdf__page-break');
     });
+
+    it('should insert a page break before a block element that overflows', async () => {
+      const longText = Array(50).fill('<p>Line</p>').join('');
+      const bigPara = `<p>${'A'.repeat(500)}</p>`;
+      const input = `${longText}${bigPara}`;
+      const result = await (adapter as any).insertPageBreaks(input);
+      expect(result).toContain('html2pdf__page-break');
+    });
   });
 
   describe('Browser environment', () => {

--- a/packages/adapters/pdf/src/pdf.adapter.ts
+++ b/packages/adapters/pdf/src/pdf.adapter.ts
@@ -108,7 +108,7 @@ export class PDFAdapter implements IDocumentConverter {
     const PAGE_HEIGHT = 9 * 96; // letter page minus 1in margins -> px
     const LINE_HEIGHT = 16; // rough text line height in px
     const IMAGE_PADDING = 20; // extra padding for images
-    const ELEMENT_MARGIN = 16; // approximate top/bottom margin per block
+    const ELEMENT_MARGIN = 24; // approximate top/bottom margin per block
 
     const breakBefore: Element[] = [];
 

--- a/packages/adapters/pdf/src/pdf.adapter.ts
+++ b/packages/adapters/pdf/src/pdf.adapter.ts
@@ -108,6 +108,7 @@ export class PDFAdapter implements IDocumentConverter {
     const PAGE_HEIGHT = 9 * 96; // letter page minus 1in margins -> px
     const LINE_HEIGHT = 16; // rough text line height in px
     const IMAGE_PADDING = 20; // extra padding for images
+    const ELEMENT_MARGIN = 16; // approximate top/bottom margin per block
 
     const breakBefore: Element[] = [];
 
@@ -128,7 +129,7 @@ export class PDFAdapter implements IDocumentConverter {
 
     const estimateHeight = (element: Element): number => {
       if (element.tagName.toLowerCase() === 'img') {
-        return imgHeights.get(element as HTMLImageElement) || 100;
+        return (imgHeights.get(element as HTMLImageElement) || 100) + ELEMENT_MARGIN;
       }
 
       const txt = element.textContent ?? '';
@@ -139,6 +140,7 @@ export class PDFAdapter implements IDocumentConverter {
       for (const img of innerImgs) {
         height += imgHeights.get(img as HTMLImageElement) || 100;
       }
+      height += ELEMENT_MARGIN;
 
       return height;
     };
@@ -153,7 +155,7 @@ export class PDFAdapter implements IDocumentConverter {
 
       const elHeight = estimateHeight(el);
 
-      if (elHeight > remaining) {
+      if (elHeight >= remaining) {
         breakBefore.push(el);
         remaining = PAGE_HEIGHT - elHeight;
       } else {

--- a/packages/adapters/pdf/src/pdf.adapter.ts
+++ b/packages/adapters/pdf/src/pdf.adapter.ts
@@ -108,7 +108,7 @@ export class PDFAdapter implements IDocumentConverter {
     const PAGE_HEIGHT = 9 * 96; // letter page minus 1in margins -> px
     const LINE_HEIGHT = 16; // rough text line height in px
     const IMAGE_PADDING = 20; // extra padding for images
-    const ELEMENT_MARGIN = 24; // approximate top/bottom margin per block
+    const ELEMENT_MARGIN = 36; // approximate top/bottom margin per block
 
     const breakBefore: Element[] = [];
 
@@ -129,7 +129,9 @@ export class PDFAdapter implements IDocumentConverter {
 
     const estimateHeight = (element: Element): number => {
       if (element.tagName.toLowerCase() === 'img') {
-        return (imgHeights.get(element as HTMLImageElement) || 100) + ELEMENT_MARGIN;
+        return (
+          (imgHeights.get(element as HTMLImageElement) || 100) + ELEMENT_MARGIN
+        );
       }
 
       const txt = element.textContent ?? '';


### PR DESCRIPTION
## Summary
- adjust PDF adapter to insert page breaks for overflowing elements
- add regression test for page breaks when block elements overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a1a1a8cc83239bbf9c088b902805