### PR TITLE
Fix TypeScript build output paths

### DIFF
--- a/packages/adapters/docx/package.json
+++ b/packages/adapters/docx/package.json
@@ -21,8 +21,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/adapters/docx/src/index.js",
-  "types": "dist/adapters/docx/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "README.md",

--- a/packages/adapters/docx/tsconfig.json
+++ b/packages/adapters/docx/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "../..",
+    "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,

--- a/packages/adapters/docx/tsconfig.json
+++ b/packages/adapters/docx/tsconfig.json
@@ -5,7 +5,11 @@
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": false
+    "sourceMap": false,
+    "paths": {
+      "html-to-document-core": ["../../core/dist"],
+      "html-to-document-core/*": ["../../core/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/__tests__/**"]

--- a/packages/adapters/pdf/package.json
+++ b/packages/adapters/pdf/package.json
@@ -22,8 +22,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/adapters/pdf/src/index.js",
-  "types": "dist/adapters/pdf/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "README.md",

--- a/packages/adapters/pdf/tsconfig.json
+++ b/packages/adapters/pdf/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "../..",
+    "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,

--- a/packages/adapters/pdf/tsconfig.json
+++ b/packages/adapters/pdf/tsconfig.json
@@ -5,7 +5,13 @@
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": false
+    "sourceMap": false,
+    "paths": {
+      "html-to-document-core": ["../../core/dist"],
+      "html-to-document-core/*": ["../../core/dist/*"],
+      "html-to-document-adapter-docx": ["../docx/dist"],
+      "html-to-document-adapter-docx/*": ["../docx/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/__tests__/**"]

--- a/packages/html-to-document/tsconfig.json
+++ b/packages/html-to-document/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "../..",
+    "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,

--- a/packages/html-to-document/tsconfig.json
+++ b/packages/html-to-document/tsconfig.json
@@ -6,7 +6,13 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
-    "sourceMap": false
+    "sourceMap": false,
+    "paths": {
+      "html-to-document-core": ["../core/dist"],
+      "html-to-document-core/*": ["../core/dist/*"],
+      "html-to-document-adapter-docx": ["../adapters/docx/dist"],
+      "html-to-document-adapter-docx/*": ["../adapters/docx/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/__tests__/**"]


### PR DESCRIPTION
## Summary
- correct `rootDir` for packages
- update paths in package.json files

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843e024a6ac8323961329d63ae8651b