### PR TITLE
Implement PDF deconversion via HTML parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           echo "core=$(jq -r '.version' packages/core/package.json)" >> "$GITHUB_OUTPUT"
           echo "docx=$(jq -r '.version' packages/adapters/docx/package.json)" >> "$GITHUB_OUTPUT"
           echo "pdf=$(jq -r '.version' packages/adapters/pdf/package.json)" >> "$GITHUB_OUTPUT"
+          echo "pdfdeconv=$(jq -r '.version' packages/deconverters/pdf/package.json)" >> "$GITHUB_OUTPUT"
           echo "wrapper=$(jq -r '.version' packages/html-to-document/package.json)" >> "$GITHUB_OUTPUT"
 
       # Publish core first
@@ -58,6 +59,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --workspace packages/adapters/pdf --access public --provenance
+
+      # Publish PDF deconverter
+      - name: Publish html-to-document-deconverter-pdf
+        if: steps.versions.outputs.tag == steps.versions.outputs.pdfdeconv
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace packages/deconverters/pdf --access public --provenance
 
       # Publish wrapper last
       - name: Publish html-to-document (wrapper)

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   roots: [
     '<rootDir>/packages/core',
     '<rootDir>/packages/adapters',
+    '<rootDir>/packages/deconverters',
   ],
 
   // Resolve workspace names inside tests
@@ -23,6 +24,8 @@ module.exports = {
     '^html-to-document-adapter-docx$':
       '<rootDir>/packages/adapters/docx/src',
     '^html-to-document-adapter-pdf$': '<rootDir>/packages/adapters/pdf/src',
+    '^html-to-document-deconverter-pdf$':
+      '<rootDir>/packages/deconverters/pdf/src',
   },
 
   testMatch: ['**/__tests__/**/*.test.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "workspaces": [
         "packages/core",
         "packages/adapters/*",
+        "packages/deconverters/*",
         "packages/html-to-document"
       ],
       "devDependencies": {
@@ -1941,6 +1942,16 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2755,6 +2766,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.24.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
@@ -2951,6 +2972,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/co": {
@@ -3494,6 +3525,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/css-line-break": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
@@ -3625,6 +3663,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -4502,6 +4547,24 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4978,6 +5041,10 @@
     },
     "node_modules/html-to-document-core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/html-to-document-deconverter-pdf": {
+      "resolved": "packages/deconverters/pdf",
       "link": true
     },
     "node_modules/html2canvas": {
@@ -6498,6 +6565,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6722,6 +6796,27 @@
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7043,8 +7138,7 @@
     "node_modules/node-ensure": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
-      "dev": true
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -7322,7 +7416,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
       "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
-      "dev": true,
       "dependencies": {
         "debug": "^3.1.0",
         "node-ensure": "^0.0.0"
@@ -7335,9 +7428,22 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/pdfkit": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.16.0.tgz",
+      "integrity": "sha512-oXMxkIqXH4uTAtohWdYA41i/f6i2ReB78uhgizN8H4hJEpgR3/Xjy3iu2InNAuwCIabN3PVs8P1D6G4+W2NH0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
       }
     },
     "node_modules/performance-now": {
@@ -7446,6 +7552,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -7770,6 +7882,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -8300,6 +8419,13 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
@@ -8451,6 +8577,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8522,6 +8655,35 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -9146,6 +9308,23 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/deconverters/pdf": {
+      "name": "html-to-document-deconverter-pdf",
+      "version": "0.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "pdf-parse": "^1.1.1"
+      },
+      "devDependencies": {
+        "pdfkit": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "html-to-document-core": "^0.3.0"
       }
     },
     "packages/html-to-document": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": [
     "packages/core",
     "packages/adapters/*",
+    "packages/deconverters/*",
     "packages/html-to-document"
   ],
   "scripts": {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -532,3 +532,15 @@ export type ConverterOptions = Omit<
 export interface IDocumentConverter {
   convert(elements: DocumentElement[]): Promise<Buffer | Blob>;
 }
+
+export interface IDocumentDeconverter {
+  deconvert(file: Buffer | Blob): Promise<DocumentElement[]>;
+}
+
+export type DeconverterProvider = new (
+  dependencies: IDeconverterDependencies
+) => IDocumentDeconverter;
+
+export interface IDeconverterDependencies {
+  [key: string]: unknown;
+}

--- a/packages/deconverters/pdf/__tests__/pdf.deconverter.test.ts
+++ b/packages/deconverters/pdf/__tests__/pdf.deconverter.test.ts
@@ -1,0 +1,20 @@
+import { PDFDeconverter } from '../src/pdf.deconverter';
+import fs from 'fs';
+
+const samplePdf = fs.readFileSync('node_modules/pdf-parse/test/data/04-valid.pdf');
+
+describe('PDFDeconverter', () => {
+  it('converts a PDF Buffer to DocumentElement[]', async () => {
+    const buffer = samplePdf;
+    const deconv = new PDFDeconverter();
+    const result = await deconv.deconvert(buffer);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('accepts a Blob as input', async () => {
+    const blob = new Blob([samplePdf], { type: 'application/pdf' });
+    const deconv = new PDFDeconverter();
+    const result = await deconv.deconvert(blob);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/deconverters/pdf/package.json
+++ b/packages/deconverters/pdf/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "html-to-document-deconverter-pdf",
+  "version": "0.1.0",
+  "description": "PDF deconverter for html-to-document-core — converts PDF files to DocumentElement[] using pdf-parse.",
+  "keywords": [
+    "html-to-document",
+    "pdf",
+    "deconverter",
+    "pdf-parse"
+  ],
+  "license": "ISC",
+  "homepage": "https://github.com/ChipiKaf/html-to-document#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ChipiKaf/html-to-document.git",
+    "directory": "packages/deconverters/pdf"
+  },
+  "bugs": {
+    "url": "https://github.com/ChipiKaf/html-to-document/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest",
+    "lint": "eslint 'src/**/*.{ts,tsx}' --ignore-pattern '**/*.d.ts'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,md}'"
+  },
+  "peerDependencies": {
+    "html-to-document-core": "^0.3.0"
+  },
+  "dependencies": {
+    "pdf-parse": "^1.1.1"
+  },
+  "devDependencies": {
+    "pdfkit": "^0.16.0"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}

--- a/packages/deconverters/pdf/src/index.ts
+++ b/packages/deconverters/pdf/src/index.ts
@@ -1,0 +1,1 @@
+export * from './pdf.deconverter';

--- a/packages/deconverters/pdf/src/pdf.deconverter.ts
+++ b/packages/deconverters/pdf/src/pdf.deconverter.ts
@@ -1,0 +1,42 @@
+import {
+  DocumentElement,
+  IDocumentDeconverter,
+  Parser,
+  IDOMParser,
+} from 'html-to-document-core';
+import { JSDOM } from 'jsdom';
+
+class JSDOMParser implements IDOMParser {
+  parse(html: string): Document {
+    const dom = new JSDOM(html);
+    return dom.window.document;
+  }
+}
+
+export class PDFDeconverter implements IDocumentDeconverter {
+  private _parser: Parser;
+
+  constructor() {
+    this._parser = new Parser([], new JSDOMParser());
+  }
+
+  async deconvert(file: Buffer | Blob): Promise<DocumentElement[]> {
+    let buffer: Buffer;
+    if (Buffer.isBuffer(file)) {
+      buffer = file;
+    } else if (file instanceof Blob) {
+      buffer = Buffer.from(await file.arrayBuffer());
+    } else {
+      throw new Error('Unsupported input type');
+    }
+
+    const pdfParse = require('pdf-parse') as (data: Buffer) => Promise<{ text: string }>;
+    const data = await pdfParse(buffer);
+    const html = data.text
+      .split(/\r?\n/) // split on newlines
+      .map((l) => `<p>${l.trim()}</p>`)
+      .join('');
+
+    return this._parser.parse(html);
+  }
+}

--- a/packages/deconverters/pdf/tsconfig.json
+++ b/packages/deconverters/pdf/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": false,
+    "paths": {
+      "html-to-document-core": ["../../core/dist"],
+      "html-to-document-core/*": ["../../core/dist/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,8 @@
     "paths": {
       "html-to-document-core": ["packages/core/src"],
       "html-to-document-core/*": ["packages/core/src/*"],
-      "html-to-document-adapter-*": ["packages/adapters/*/src"]
+      "html-to-document-adapter-*": ["packages/adapters/*/src"],
+      "html-to-document-deconverter-*": ["packages/deconverters/*/src"]
     },
     "target": "ES2024",
     "module": "ESNext",


### PR DESCRIPTION
## Summary
- parse PDF text lines into HTML
- feed generated HTML through core Parser
- update PDF deconverter tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847f7acb94483239b3d8497a403d55f