### PR TITLE
fix(docx-adapter): added fallback to inline element handlers

### DIFF
--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -1525,4 +1525,15 @@ describe('Docx.adapter.convert', () => {
       expect(footerText).toBe('Plain Footer');
     });
   });
+
+  it('inline handler should fall back to text if no handler was found', async () => {
+    const html =
+      '<p><strong><em>Fallback</em> <custom>text</custom></strong></p>';
+
+    const elements = parser.parse(html);
+    const buffer = await adapter.convert(elements);
+    const json = await parseDocxDocument(buffer);
+
+    expect(json['w:document']['w:body']['w:p']).toBeDefined();
+  });
 });

--- a/packages/adapters/docx/src/docx.adapter.ts
+++ b/packages/adapters/docx/src/docx.adapter.ts
@@ -177,6 +177,7 @@ export class DocxAdapter implements IDocumentConverter {
   > = {
     text: this.convertText.bind(this),
     image: this.convertImage.bind(this),
+    custom: this.convertText.bind(this), // fallback
   };
 
   /**


### PR DESCRIPTION
Currently the following HTML would result in an error

```html
<p><strong><em>Fallback</em> <custom>text</custom></strong></p>
```

Simply adding the convertText as the custom inline handler should resolve that issue