### PR TITLE
chore: fix format:check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:silent": "jest --runInBand --silent",
     "lint": "eslint 'packages/**/*.{ts,tsx}' --ignore-pattern '**/*.d.ts'",
     "format": "prettier --write 'packages/**/*.{ts,tsx,js,jsx,json,css,md}'",
-    "format:check": "prettier 'packages/**/*.{ts,tsx,js,jsx,json,css,md}'",
+    "format:check": "prettier --check 'packages/**/*.{ts,tsx,js,jsx,json,css,md}'",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "changelog:all": "node scripts/generate-changelog.js"
   },


### PR DESCRIPTION
Adding `--check` flag to the `format:check` script