### PR TITLE
chore: move peer internal dependencies to dependencies

### DIFF
--- a/packages/adapters/docx/package.json
+++ b/packages/adapters/docx/package.json
@@ -52,18 +52,15 @@
   },
   "dependencies": {
     "docx": "^9.4.0",
+    "html-to-document-core": "workspace:*",
     "image-size": "^2.0.2",
     "jszip": "^3.10.1"
   },
   "engines": {
     "node": ">=14"
   },
-  "peerDependencies": {
-    "html-to-document-core": "workspace:*"
-  },
   "devDependencies": {
     "@types/probe-image-size": "^7.2.5",
-    "html-to-document-core": "workspace:^",
     "ts-toolbelt": "^9.6.0",
     "vitest": "^3.2.4"
   }

--- a/packages/adapters/pdf/package.json
+++ b/packages/adapters/pdf/package.json
@@ -52,6 +52,8 @@
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,md}'"
   },
   "dependencies": {
+    "html-to-document-core": "workspace:*",
+    "html-to-document-adapter-docx": "workspace:^",
     "html2pdf.js": "^0.10.2",
     "libreoffice-convert": "^1.6.1",
     "mammoth": "^1.6.0",
@@ -61,12 +63,9 @@
     "node": ">=14"
   },
   "peerDependencies": {
-    "html-to-document-core": "workspace:*",
     "jsdom": "*"
   },
   "devDependencies": {
-    "html-to-document-core": "workspace:*",
-    "html-to-document-adapter-docx": "workspace:^",
     "pdf-parse": "^1.1.1",
     "vitest": "^3.2.4"
   }

--- a/packages/deconverters/pdf/package.json
+++ b/packages/deconverters/pdf/package.json
@@ -37,14 +37,13 @@
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,md}'"
   },
   "dependencies": {
+    "html-to-document-core": "workspace:*",
     "pdf-parse": "^1.1.1"
   },
   "peerDependencies": {
-    "html-to-document-core": "workspace:*",
     "jsdom": "*"
   },
   "devDependencies": {
-    "html-to-document-core": "workspace:*",
     "pdfkit": "^0.16.0",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       docx:
         specifier: ^9.4.0
         version: 9.5.1
+      html-to-document-core:
+        specifier: workspace:*
+        version: link:../../core
       image-size:
         specifier: ^2.0.2
         version: 2.0.2
@@ -122,9 +125,6 @@ importers:
       '@types/probe-image-size':
         specifier: ^7.2.5
         version: 7.2.5
-      html-to-document-core:
-        specifier: workspace:^
-        version: link:../../core
       ts-toolbelt:
         specifier: ^9.6.0
         version: 9.6.0
@@ -134,6 +134,12 @@ importers:
 
   packages/adapters/pdf:
     dependencies:
+      html-to-document-adapter-docx:
+        specifier: workspace:^
+        version: link:../docx
+      html-to-document-core:
+        specifier: workspace:*
+        version: link:../../core
       html2pdf.js:
         specifier: ^0.10.2
         version: 0.10.3
@@ -150,12 +156,6 @@ importers:
         specifier: ^1.1.0
         version: 1.2.0
     devDependencies:
-      html-to-document-adapter-docx:
-        specifier: workspace:^
-        version: link:../docx
-      html-to-document-core:
-        specifier: workspace:*
-        version: link:../../core
       pdf-parse:
         specifier: ^1.1.1
         version: 1.1.1
@@ -193,6 +193,9 @@ importers:
 
   packages/deconverters/pdf:
     dependencies:
+      html-to-document-core:
+        specifier: workspace:*
+        version: link:../../core
       jsdom:
         specifier: '*'
         version: 26.1.0
@@ -200,9 +203,6 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
-      html-to-document-core:
-        specifier: workspace:*
-        version: link:../../core
       pdfkit:
         specifier: ^0.16.0
         version: 0.16.0


### PR DESCRIPTION
It seems like changesets is trying to bump the packages a major version, even though i have only added a minor change. I think it will resolve the issue by removing the peer dependency and adding it as a dependency.