### PR TITLE
refactor(pdf-adapter): change converter

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -49,6 +49,9 @@ export default defineConfig({
         : path.resolve(__dirname, 'src/index.ts'),
     },
   },
+  define: {
+    global: 'globalThis',
+  },
   build: {
     outDir: 'dist',
   },

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -12,6 +12,10 @@ const devAliases = isDev
         __dirname,
         '../packages/adapters/docx/src/index.ts'
       ),
+      'html-to-document-adapter-pdf': path.resolve(
+        __dirname,
+        '../packages/adapters/pdf/src/index.ts'
+      ),
       'html-to-document-core': path.resolve(
         __dirname,
         '../packages/core/src/index.ts'

--- a/packages/adapters/pdf/package.json
+++ b/packages/adapters/pdf/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@types/pdfkit": "^0.13.9",
+    "csstype": "^3.2.3",
     "html-to-document-adapter-docx": "workspace:^",
     "html-to-document-core": "workspace:*",
     "pdf-parse": "^1.1.1",

--- a/packages/adapters/pdf/package.json
+++ b/packages/adapters/pdf/package.json
@@ -47,9 +47,11 @@
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,md}'"
   },
   "dependencies": {
+    "blob-stream": "^0.1.3",
     "html2pdf.js": "^0.10.2",
     "libreoffice-convert": "^1.6.1",
     "mammoth": "^1.6.0",
+    "pdfkit": "^0.16.0",
     "zetajs": "^1.1.0"
   },
   "engines": {
@@ -60,8 +62,9 @@
     "jsdom": "*"
   },
   "devDependencies": {
-    "html-to-document-core": "workspace:*",
+    "@types/pdfkit": "^0.13.9",
     "html-to-document-adapter-docx": "workspace:^",
+    "html-to-document-core": "workspace:*",
     "pdf-parse": "^1.1.1",
     "vitest": "^3.2.4"
   }

--- a/packages/adapters/pdf/src/pdf.adapter.ts
+++ b/packages/adapters/pdf/src/pdf.adapter.ts
@@ -38,6 +38,7 @@ export class PDFAdapter implements IDocumentConverter {
   }
 
   private convertElement(doc: typeof PDFDocument, elements: DocumentElement[]) {
+    console.log('PDFAdapter: convertElement called with elements:', elements);
     for (const element of elements) {
       switch (element.type) {
         case 'page': {
@@ -45,14 +46,16 @@ export class PDFAdapter implements IDocumentConverter {
           this.convertElement(doc, element.content || []);
           break;
         }
-        // case 'heading': {
-        //   if (element.text) {
-        //     doc.text(element.text);
-        //   } else {
-        //     this.convertElement(doc, element.content || []);
-        //   }
-        //   break;
-        // }
+        case 'heading': {
+          // doc.fontSize();
+          if (element.text) {
+            doc.text(element.text);
+          } else {
+            this.convertElement(doc, element.content || []);
+          }
+          doc.fontSize(12); // Reset to default)
+          break;
+        }
         case 'text': {
           if (element.text) {
             doc.text(element.text);

--- a/packages/adapters/pdf/src/pdfkit-standalone.d.ts
+++ b/packages/adapters/pdf/src/pdfkit-standalone.d.ts
@@ -1,0 +1,4 @@
+declare module 'pdfkit/js/pdfkit.standalone' {
+  var doc: PDFKit.PDFDocument;
+  export = doc;
+}

--- a/packages/adapters/pdf/src/style-stack.ts
+++ b/packages/adapters/pdf/src/style-stack.ts
@@ -1,0 +1,30 @@
+import { ElementType } from 'packages/core/dist';
+import type CSS from 'csstype';
+import type PDFDocument from 'pdfkit/js/pdfkit.standalone';
+
+export class StyleStack {
+  constructor(
+    private readonly doc: typeof PDFDocument,
+    private readonly defaultStyles: Partial<
+      Record<
+        ElementType,
+        Partial<Record<keyof CSS.Properties, string | number>>
+      >
+    >
+  ) {}
+
+  pushLayer(
+    styles: Partial<
+      Record<
+        ElementType,
+        Partial<Record<keyof CSS.Properties, string | number>>
+      >
+    >
+  ) {
+    // TODO: apply the new styles to the PDF document
+  }
+
+  popLayer() {
+    // TODO: check which styles were changed in the current layer and revert them
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       '@types/pdfkit':
         specifier: ^0.13.9
         version: 0.13.9
+      csstype:
+        specifier: ^3.2.3
+        version: 3.2.3
       html-to-document-adapter-docx:
         specifier: workspace:^
         version: link:../docx
@@ -4836,6 +4839,7 @@ packages:
 
   jpeg-exif@1.1.4:
     resolution: {integrity: sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7435,6 +7439,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
 
   packages/adapters/pdf:
     dependencies:
+      blob-stream:
+        specifier: ^0.1.3
+        version: 0.1.3
       html2pdf.js:
         specifier: ^0.10.2
         version: 0.10.3
@@ -186,10 +189,16 @@ importers:
       mammoth:
         specifier: ^1.6.0
         version: 1.10.0
+      pdfkit:
+        specifier: ^0.16.0
+        version: 0.16.0
       zetajs:
         specifier: ^1.1.0
         version: 1.2.0
     devDependencies:
+      '@types/pdfkit':
+        specifier: ^0.13.9
+        version: 0.13.9
       html-to-document-adapter-docx:
         specifier: workspace:^
         version: link:../docx
@@ -2937,6 +2946,12 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  blob-stream@0.1.3:
+    resolution: {integrity: sha512-xXwyhgVmPsFVFFvtM5P0syI17/oae+MIjLn5jGhuD86mmSJ61EWMWmbPrV/0+bdcH9jQ2CzIhmTQKNUJL7IPog==}
+
+  blob@0.0.4:
+    resolution: {integrity: sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg==}
 
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
@@ -11497,6 +11512,12 @@ snapshots:
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
+
+  blob-stream@0.1.3:
+    dependencies:
+      blob: 0.0.4
+
+  blob@0.0.4: {}
 
   bluebird@3.4.7: {}
 


### PR DESCRIPTION
This PR changes the converter to use [`pdfkit`](https://github.com/foliojs/pdfkit).

The current problem is that the pdf converter uses either a canvas based approach, which just results in an image or a poorly formatted pdf document or it uses libreoffice-convert, which may not be available in all environments and would require more setup.