### PR TITLE
feat(core): style mapper border shorthands

### DIFF
--- a/packages/core/src/utils/html.utils.ts
+++ b/packages/core/src/utils/html.utils.ts
@@ -64,6 +64,19 @@ export function pixelsToTwips(pixels: number): number {
   return Math.round(pixels * 10); // 1px = 15 twips (approx)
 }
 
+export const borderStyleValues = [
+  'none',
+  'hidden',
+  'dotted',
+  'dashed',
+  'solid',
+  'double',
+  'groove',
+  'ridge',
+  'inset',
+  'outset',
+] as const;
+
 export function mapBorderStyle(style: string): string {
   switch (style.toLowerCase()) {
     case 'none':

--- a/packages/core/src/utils/text.ts
+++ b/packages/core/src/utils/text.ts
@@ -1,0 +1,3 @@
+export const capitalize = (text: string): string => {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+};


### PR DESCRIPTION
You can now use all border shorthands `border`, `borderTop`, `borderRight`, ..., `borderWidth`, `borderStyle`, ...

One question I have @ChipiKaf : Should we check if the elements are table or table cell? I noticed that some of the previous code did check whether it was a table or table cell, but I am not sure why :)