### PR TITLE
feat(docx): text converter will add breaks if it contains newlines

### DIFF
--- a/.changeset/curly-taxes-jump.md
+++ b/.changeset/curly-taxes-jump.md
@@ -1,0 +1,6 @@
+---
+'html-to-document-adapter-docx': minor
+'html-to-document-core': minor
+---
+
+Added split text node by newlines utility and docx text converter will split them by default

--- a/packages/core/__tests__/adapter-utilities/split-text-breaks.test.ts
+++ b/packages/core/__tests__/adapter-utilities/split-text-breaks.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { splitTextElementByLineBreaks } from '../../src/adapter-utilities/split-text-breaks';
+
+describe('splitTextBreaks', () => {
+  it('should keep a single text element if it only contains text without line breaks', () => {
+    const result = splitTextElementByLineBreaks({
+      type: 'text',
+      text: 'Hello, world!',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: 'text',
+      text: 'Hello, world!',
+    });
+  });
+
+  it('should add break metadata for trailing line breaks', () => {
+    const result = splitTextElementByLineBreaks({
+      type: 'text',
+      text: 'Hello\n\n',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      type: 'text',
+      text: 'Hello',
+      metadata: {
+        break: 2,
+      },
+    });
+  });
+
+  it('should split text element by line breaks and preserve break metadata', () => {
+    const result = splitTextElementByLineBreaks({
+      type: 'text',
+      text: 'Line 1\nLine 2\n\nLine 4',
+      metadata: {
+        customData: 'example',
+      },
+    });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      type: 'text',
+      text: 'Line 1',
+      metadata: {
+        customData: 'example',
+        break: 1,
+      },
+    });
+    expect(result[1]).toEqual({
+      type: 'text',
+      text: 'Line 2',
+      metadata: {
+        customData: 'example',
+        break: 2,
+      },
+    });
+    expect(result[2]).toEqual({
+      type: 'text',
+      text: 'Line 4',
+      metadata: {
+        customData: 'example',
+      },
+    });
+  });
+
+  it('should handle text starting with line breaks', () => {
+    const result = splitTextElementByLineBreaks({
+      type: 'text',
+      text: '\n\nStart here',
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      type: 'text',
+      text: '',
+      metadata: {
+        break: 2,
+      },
+    });
+    expect(result[1]).toEqual({
+      type: 'text',
+      text: 'Start here',
+    });
+  });
+});

--- a/packages/core/src/adapter-utilities/index.ts
+++ b/packages/core/src/adapter-utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './split-text-breaks';

--- a/packages/core/src/adapter-utilities/split-text-breaks.ts
+++ b/packages/core/src/adapter-utilities/split-text-breaks.ts
@@ -1,0 +1,47 @@
+import { TextElement } from '../types';
+
+export const splitTextElementByLineBreaks = (
+  element: TextElement
+): TextElement[] => {
+  const textParts = (element.text || '').split('\n');
+
+  let currentSegment = {
+    // if parts[0] is empty, it means the text starts with a line break, if there are more than 1 part. If there is only one part it means that the initial text is empty
+    trailingBreaks: 0,
+    text: textParts[0] ?? '',
+  };
+  const segments = [currentSegment];
+
+  for (let i = 1; i < textParts.length; i++) {
+    const textSegment = textParts[i]!;
+    currentSegment.trailingBreaks += 1;
+    if (textSegment === '') {
+      continue;
+    }
+    currentSegment = {
+      trailingBreaks: 0,
+      text: textSegment,
+    };
+    segments.push(currentSegment);
+  }
+
+  const lastSegment = currentSegment;
+  const finalBreaks =
+    typeof element.metadata?.break === 'number'
+      ? element.metadata.break
+      : Number(element.metadata?.break) || 0;
+  lastSegment.trailingBreaks += finalBreaks;
+
+  return segments.map((segment) => ({
+    ...element,
+    text: segment.text,
+    metadata:
+      element.metadata || segment.trailingBreaks >= 1
+        ? {
+            ...element.metadata,
+            break:
+              segment.trailingBreaks >= 1 ? segment.trailingBreaks : undefined,
+          }
+        : undefined,
+  }));
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { init } from './converter';
+export * from './adapter-utilities';
 export * from './types';
 export * from './middleware';
 export * from './parser';


### PR DESCRIPTION
This PR attempts to preserve newlines in text conversion.

I haven't added tests yet as we need to address the TODOs that I have added:

1. Should this only happen for certain elements such as `<pre>`
2. Should it only happen if the `whiteSpace` style have been set to either `pre`, `pre-wrap`, `pre-line` or `preserve-breaks`?

alternatively

3. Should it happen if a metadata attribute has been set on the element?

**Note**

In my own application I have an absolute positioned text box (`<div>`) with some paragraphs inside, this causes an issue when I try to convert it to docx, since a text frame is a single paragraph, so I have to convert the paragraphs to inline elements. This means that the breaks between paragraphs disappear.

What I would like to do at some point is that if you convert to inline on paragraphs, it might insert some newlines, so that it preserves the original structure.

Before merge:

- [x] Add tests
- [x] Add changeset