### PR TITLE
fix: DOCX converter cannot convert empty table

### DIFF
--- a/.changeset/whole-mugs-melt.md
+++ b/.changeset/whole-mugs-melt.md
@@ -1,0 +1,5 @@
+---
+'html-to-document-adapter-docx': patch
+---
+
+DOCX: fix: empty tables will not break the converted output

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -1635,6 +1635,18 @@ describe('Docx.adapter.convert', () => {
       return body['w:tbl'];
     };
 
+    it('should convert an empty table without failing', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        rows: [],
+        styles: {},
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      expect(jsonDocument).toBeDefined();
+    });
+
     it('should convert a simple table with one row and one cell', async () => {
       const table: DocumentElement = {
         type: 'table',

--- a/packages/adapters/docx/src/element-converters/block/table.ts
+++ b/packages/adapters/docx/src/element-converters/block/table.ts
@@ -105,8 +105,10 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
       numCols = Math.max(numCols, colCount);
     }
 
+    const effectiveNumCols = Math.max(numCols, 1);
+
     const grid: (GridCell | null)[][] = Array.from({ length: numRows }, () => {
-      return Array(numCols).fill(null);
+      return Array(effectiveNumCols).fill(null);
     });
 
     for (let i = 0; i < numRows; i++) {
@@ -116,8 +118,9 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
 
       for (const cell of row.cells) {
         const currentRow = grid[i]!;
-        while (colIndex < numCols && currentRow[colIndex] !== null) colIndex++;
-        if (colIndex >= numCols) break;
+        while (colIndex < effectiveNumCols && currentRow[colIndex] !== null)
+          colIndex++;
+        if (colIndex >= effectiveNumCols) break;
         const colSpan = cell.colspan || 1;
         const rowSpan = cell.rowspan || 1;
 
@@ -158,7 +161,7 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
     for (let i = 0; i < numRows; i++) {
       const cells: TableCell[] = [];
       let j = 0;
-      while (j < numCols) {
+      while (j < effectiveNumCols) {
         const gridCell = grid[i]?.[j];
         if (!gridCell) {
           cells.push(
@@ -261,6 +264,13 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
         })
       );
     }
+
+    // Drop table if it has no rows
+    if (tableRows.length === 0) {
+      // TODO: return captions?
+      return [];
+    }
+
     const rawStyles = styleMapper.mapStyles(
       { ...mergedStyles, ...element.styles },
       element

--- a/packages/adapters/docx/vitest.config.ts
+++ b/packages/adapters/docx/vitest.config.ts
@@ -1,3 +1,10 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: {
+    alias: {
+      'html-to-document-core': resolve(__dirname, '../../core/src/index.ts'),
+    },
+  },
+});


### PR DESCRIPTION
Currently if an empty table is provided to the DOCX converter, the converter throws an error.

This PR aims to fix that issue. Either by just not rendering the table or actually just rendering an empty table, if that is possible with docx.js or docx in general.

Currently I have only added a test to this PR, so that when the CI passes, it can be merged.