### PR TITLE
chore(deps): internal dependencies to dependencies not peer

### DIFF
--- a/packages/adapters/docx/package.json
+++ b/packages/adapters/docx/package.json
@@ -54,18 +54,15 @@
   },
   "dependencies": {
     "docx": "^9.4.0",
+    "html-to-document-core": "workspace:*",
     "jszip": "^3.10.1",
     "remeda": "^2.32.0"
   },
   "engines": {
     "node": ">=14"
   },
-  "peerDependencies": {
-    "html-to-document-core": "workspace:*"
-  },
   "devDependencies": {
     "@types/probe-image-size": "^7.2.5",
-    "html-to-document-core": "workspace:^",
     "ts-toolbelt": "^9.6.0",
     "vitest": "^3.2.4"
   }

--- a/packages/adapters/pdf/package.json
+++ b/packages/adapters/pdf/package.json
@@ -47,6 +47,7 @@
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,md}'"
   },
   "dependencies": {
+    "html-to-document-core": "workspace:*",
     "html2pdf.js": "^0.10.2",
     "libreoffice-convert": "^1.6.1",
     "mammoth": "^1.6.0",
@@ -56,11 +57,9 @@
     "node": ">=14"
   },
   "peerDependencies": {
-    "html-to-document-core": "workspace:*",
     "jsdom": "*"
   },
   "devDependencies": {
-    "html-to-document-core": "workspace:*",
     "html-to-document-adapter-docx": "workspace:^",
     "pdf-parse": "^1.1.1",
     "vitest": "^3.2.4"

--- a/packages/deconverters/pdf/package.json
+++ b/packages/deconverters/pdf/package.json
@@ -37,14 +37,13 @@
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,md}'"
   },
   "dependencies": {
+    "html-to-document-core": "workspace:*",
     "pdf-parse": "^1.1.1"
   },
   "peerDependencies": {
-    "html-to-document-core": "workspace:*",
     "jsdom": "*"
   },
   "devDependencies": {
-    "html-to-document-core": "workspace:*",
     "pdfkit": "^0.16.0",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       docx:
         specifier: ^9.4.0
         version: 9.5.1
+      html-to-document-core:
+        specifier: workspace:*
+        version: link:../../core
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -162,9 +165,6 @@ importers:
       '@types/probe-image-size':
         specifier: ^7.2.5
         version: 7.2.5
-      html-to-document-core:
-        specifier: workspace:^
-        version: link:../../core
       ts-toolbelt:
         specifier: ^9.6.0
         version: 9.6.0
@@ -174,6 +174,9 @@ importers:
 
   packages/adapters/pdf:
     dependencies:
+      html-to-document-core:
+        specifier: workspace:*
+        version: link:../../core
       html2pdf.js:
         specifier: ^0.10.2
         version: 0.10.3
@@ -193,9 +196,6 @@ importers:
       html-to-document-adapter-docx:
         specifier: workspace:^
         version: link:../docx
-      html-to-document-core:
-        specifier: workspace:*
-        version: link:../../core
       pdf-parse:
         specifier: ^1.1.1
         version: 1.1.1
@@ -236,6 +236,9 @@ importers:
 
   packages/deconverters/pdf:
     dependencies:
+      html-to-document-core:
+        specifier: workspace:*
+        version: link:../../core
       jsdom:
         specifier: '*'
         version: 26.1.0
@@ -243,9 +246,6 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
-      html-to-document-core:
-        specifier: workspace:*
-        version: link:../../core
       pdfkit:
         specifier: ^0.16.0
         version: 0.16.0


### PR DESCRIPTION
This will make sure that the adapters won't get major bumped when an update happens in one of the core packages