### PR TITLE
feat(docx): stylemapper can convert fontSize and more from more units

### DIFF
--- a/.changeset/twelve-wombats-shave.md
+++ b/.changeset/twelve-wombats-shave.md
@@ -1,0 +1,5 @@
+---
+'html-to-document-adapter-docx': minor
+---
+
+DOCX: stylemapper can convert from more units for border, fontSize and more

--- a/packages/adapters/docx/__tests__/docx-style-mapper.test.ts
+++ b/packages/adapters/docx/__tests__/docx-style-mapper.test.ts
@@ -51,10 +51,34 @@ describe('DocxStyleMapper', () => {
   it('maps fontSize and lineHeight', () => {
     const el = { type: 'paragraph' } as DocumentElement;
     expect(mapper.mapStyles({ fontSize: '20px' }, el)).toEqual({
-      size: Math.round(20 * 1.5),
+      size: 30,
     });
     expect(mapper.mapStyles({ fontSize: '200%' }, el)).toEqual({
-      size: Math.round(16 * (200 / 100) * 1.5),
+      size: 48,
+    });
+    expect(mapper.mapStyles({ fontSize: '12pt' }, el)).toEqual({
+      size: 24,
+    });
+    expect(mapper.mapStyles({ fontSize: '1pc' }, el)).toEqual({
+      size: 24,
+    });
+    expect(mapper.mapStyles({ fontSize: '2.54cm' }, el)).toEqual({
+      size: 144,
+    });
+    expect(mapper.mapStyles({ fontSize: '25.4mm' }, el)).toEqual({
+      size: 144,
+    });
+    expect(mapper.mapStyles({ fontSize: '1in' }, el)).toEqual({
+      size: 144,
+    });
+    expect(mapper.mapStyles({ fontSize: '1.5em' }, el)).toEqual({
+      size: 36,
+    });
+    expect(mapper.mapStyles({ fontSize: '1.5rem' }, el)).toEqual({
+      size: 36,
+    });
+    expect(mapper.mapStyles({ fontSize: '20' }, el)).toEqual({
+      size: 30,
     });
     expect(mapper.mapStyles({ lineHeight: '2' }, el)).toEqual({
       spacing: { line: Math.round(2 * 240), lineRule: 'auto' },
@@ -165,17 +189,29 @@ describe('DocxStyleMapper', () => {
 
   it('maps border and borderWidth for various contexts', () => {
     const img = { type: 'image' } as DocumentElement;
-    const br = mapper.mapStyles({ border: '2px dashed #000' }, img) as any;
-    expect(br.outline).toBeDefined();
+    const br = mapper.mapStyles({ border: '12pt dashed #000' }, img) as any;
+    expect(br.outline).toEqual({
+      width: 152400,
+      type: 'solidFill',
+      solidFillType: 'rgb',
+      value: '000000',
+    });
     const cell = { type: 'table-cell' } as DocumentElement;
     const none = mapper.mapStyles({ border: 'none' }, cell) as any;
     expect(none.borders.top.style).toBe(BorderStyle.NONE);
     const t = { type: 'table' } as DocumentElement;
-    const bw = mapper.mapStyles({ borderWidth: '2' } as any, t) as any;
-    expect(bw.borders).toBeDefined();
+    const bw = mapper.mapStyles({ borderWidth: '12pt' } as any, t) as any;
+    expect(bw.borders.top.size).toBe(96);
     const p = { type: 'paragraph' } as DocumentElement;
-    const bwp = mapper.mapStyles({ borderWidth: '2' } as any, p) as any;
-    expect(bwp.border).toBeDefined();
+    const bwp = mapper.mapStyles({ borderWidth: '1in' } as any, p) as any;
+    expect(bwp.border.left.size).toBe(576);
+  });
+
+  it('maps letterSpacing with shared length conversion', () => {
+    const el = { type: 'paragraph' } as DocumentElement;
+    expect(mapper.mapStyles({ letterSpacing: '12pt' }, el)).toEqual({
+      characterSpacing: 240,
+    });
   });
 
   it('executes all mapping functions without throwing', () => {

--- a/packages/adapters/docx/src/docx-style-mapper.ts
+++ b/packages/adapters/docx/src/docx-style-mapper.ts
@@ -19,6 +19,11 @@ import {
   ITableRowOptions,
   ISpacingProperties,
 } from 'docx';
+import {
+  twipsToEighthsOfPoint,
+  twipsToEmus,
+  twipsToHalfPoints,
+} from './utils/unit-conversion';
 
 type StyleKey = keyof Styles;
 
@@ -71,6 +76,11 @@ const mapBorderStyle = (style: string): string => {
     default:
       return BorderStyle.SINGLE;
   }
+};
+
+const lengthToBorderSize = (value: string): number | undefined => {
+  const twips = lengthToTwips(value);
+  return typeof twips === 'number' ? twipsToEighthsOfPoint(twips) : undefined;
 };
 
 function deepMerge<T extends object, U extends object>(
@@ -230,17 +240,10 @@ export class DocxStyleMapper {
 
       // Font size
       fontSize: (v) => {
-        if (v.endsWith('px')) {
-          const px = parseFloat(v.slice(0, -2));
-          return { size: Math.round(px * 1.5) };
-        } else if (v.endsWith('%')) {
-          const base = 16;
-          const percent = parseFloat(v.slice(0, -1));
-          return { size: Math.round(base * (percent / 100) * 1.5) };
-        } else {
-          const num = parseFloat(v);
-          return !isNaN(num) ? { size: Math.round(num * 1.5) } : {};
-        }
+        const twips = lengthToTwips(v, { basePx: BASE_FONT_SIZE_PX });
+        return typeof twips === 'number'
+          ? { size: twipsToHalfPoints(twips) }
+          : {};
       },
 
       // Line height and spacing
@@ -328,8 +331,8 @@ export class DocxStyleMapper {
       },
 
       letterSpacing: (v) => {
-        const px = parseFloat(v);
-        return !isNaN(px) ? { characterSpacing: Math.round(px * 10) } : {};
+        const twips = lengthToTwips(v);
+        return typeof twips === 'number' ? { characterSpacing: twips } : {};
       },
       border: (v: string, el) => {
         const raw = v.trim();
@@ -337,17 +340,15 @@ export class DocxStyleMapper {
         if (el.type === 'image') {
           // expect format: "<width> <style> <color>" (e.g. "2px dashed #333")
           const parts = raw.split(/\s+/);
-          // parse width (px assumed)
           const widthPart = parts[0] || '';
-          const px = parseFloat(widthPart);
-          if (!isNaN(px) && parts.length >= 2) {
+          const width = lengthToTwips(widthPart);
+          if (typeof width === 'number' && parts.length >= 2) {
             // parse color as last part
             const colorPart = parts.slice(2).join(' ') || (parts[1] ?? '');
             const color = colorConversion(colorPart);
             return {
               outline: {
-                // width in eighths of a point (approx px * 8)
-                width: Math.round(px * 8),
+                width: twipsToEmus(width),
                 // solid fill stroke of outline
                 type: 'solidFill',
                 solidFillType: 'rgb',
@@ -360,36 +361,36 @@ export class DocxStyleMapper {
         return {};
       },
       borderWidth: (v, el) => {
-        const w = parseFloat(v);
-        return isNaN(w)
+        const size = lengthToBorderSize(v);
+        return size === undefined
           ? {}
           : el.type === 'table'
             ? {
                 borders: {
                   top: {
                     style: BorderStyle.SINGLE,
-                    size: w * 8,
+                    size,
                   },
                   bottom: {
                     style: BorderStyle.SINGLE,
-                    size: w * 8,
+                    size,
                   },
                   left: {
                     style: BorderStyle.SINGLE,
-                    size: w * 8,
+                    size,
                   },
                   right: {
                     style: BorderStyle.SINGLE,
-                    size: w * 8,
+                    size,
                   },
                 },
               }
             : {
                 border: {
-                  top: { size: w * 8 },
-                  bottom: { size: w * 8 },
-                  left: { size: w * 8 },
-                  right: { size: w * 8 },
+                  top: { size },
+                  bottom: { size },
+                  left: { size },
+                  right: { size },
                 },
               };
       },
@@ -430,12 +431,12 @@ export class DocxStyleMapper {
             [
               `border${capDir}Width` satisfies StyleKey,
               (v: string) => {
-                const w = parseFloat(v);
-                return isNaN(w)
+                const size = lengthToBorderSize(v);
+                return size === undefined
                   ? {}
                   : {
-                      borders: { [dir]: { size: w * 8 } },
-                      border: { [dir]: { size: w * 8 } },
+                      borders: { [dir]: { size } },
+                      border: { [dir]: { size } },
                     };
               },
             ],

--- a/packages/adapters/docx/src/utils/unit-conversion.ts
+++ b/packages/adapters/docx/src/utils/unit-conversion.ts
@@ -6,6 +6,7 @@ export const TWIPS_PER_INCH = 1440; // 1 inch = 1440 twips
 export const TWIPS_PER_CM = 567; // 1 cm = 567 twips
 export const TWIPS_PER_MM = 56.7;
 export const CM_PER_INCH = 2.54;
+export const EMUS_PER_TWIP = 635;
 
 export const pixelsToTwips = (pixels: number): number => {
   return Math.round(pixels * TWIPS_PER_PIXEL);
@@ -25,4 +26,16 @@ export const cmToInches = (cm: number): number => {
 
 export const inchesToPixels = (inches: number): number => {
   return Math.round(inches * DPI);
+};
+
+export const twipsToHalfPoints = (twips: number): number => {
+  return Math.round(twips / 10);
+};
+
+export const twipsToEighthsOfPoint = (twips: number): number => {
+  return Math.round((twips * 8) / TWIPS_PER_PT);
+};
+
+export const twipsToEmus = (twips: number): number => {
+  return Math.round(twips * EMUS_PER_TWIP);
 };


### PR DESCRIPTION
I am not sure about the border width, but I think this commit is self-explanatory