### PR TITLE
fix(docx): use correct stylesheet

### DIFF
--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -2653,6 +2653,24 @@ describe('Docx.adapter.convert', () => {
       }
     });
 
+    it('should expand two-value @page margin shorthand', async () => {
+      const stylesheet = createStylesheetWithPageRules([
+        { descriptors: { margin: '1cm 2cm' } },
+      ]);
+      const customAdapter = new DocxAdapter({ stylesheet });
+
+      const html = '<p>Test</p>';
+      const elements = parser.parse(html);
+      const buffer = await customAdapter.convert(elements);
+      const parsed = await parseDocxXml(buffer, 'word/document.xml');
+      const sectPr = parsed['w:document']['w:body']['w:sectPr'];
+
+      expect(sectPr['w:pgMar']['@_w:top']).toBe('567');
+      expect(sectPr['w:pgMar']['@_w:right']).toBe('1134');
+      expect(sectPr['w:pgMar']['@_w:bottom']).toBe('567');
+      expect(sectPr['w:pgMar']['@_w:left']).toBe('1134');
+    });
+
     it('should apply per-side @page margins', async () => {
       const stylesheet = createStylesheetWithPageRules([
         {

--- a/packages/adapters/docx/src/docx.adapter.ts
+++ b/packages/adapters/docx/src/docx.adapter.ts
@@ -168,7 +168,7 @@ export class DocxAdapter implements IDocumentConverter {
       ? await this.convertFooter(globalFooter, effectiveStylesheet)
       : undefined;
 
-    const stylesheetPageRules = this._stylesheet.getAtRules('page');
+    const stylesheetPageRules = effectiveStylesheet.getAtRules('page');
     const defaultPageRules = stylesheetPageRules.filter((r) => !r.prelude);
 
     const validatedPageRules = this.normalizePageRules(defaultPageRules);

--- a/packages/e2e-tests/__tests__/css-parser.test.ts
+++ b/packages/e2e-tests/__tests__/css-parser.test.ts
@@ -75,6 +75,149 @@ describe('e2e tests for the css parser plugin', () => {
     );
   });
 
+  it('preserves multi-value @page margin descriptors in adapter-facing stylesheet statements', async () => {
+    let receivedStatements: readonly StylesheetStatement[] = [];
+
+    class StyleCaptureAdapter implements IDocumentConverter {
+      async convert(
+        _parsed: unknown,
+        stylesheet?: IStylesheet
+      ): Promise<Buffer> {
+        receivedStatements = stylesheet?.getStatements() ?? [];
+        return Buffer.from('ok');
+      }
+    }
+
+    const converter = init({
+      domParser: new JSDOMParser(),
+      plugins: [cssParserPlugin()],
+      adapters: {
+        register: [
+          {
+            format: 'style-capture',
+            adapter: StyleCaptureAdapter,
+          },
+        ],
+      },
+    });
+
+    await converter.convert(
+      '<style>@page { margin: 1cm 2cm; }</style><p>Page margins</p>',
+      'style-capture'
+    );
+
+    expect(receivedStatements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'at-rule',
+          name: 'page',
+          descriptors: {
+            margin: '1cm 2cm',
+          },
+        }),
+      ])
+    );
+  });
+
+  it.each([
+    ['3 values', '1cm 2cm 3cm'],
+    ['4 values', '1cm 2cm 3cm 4cm'],
+  ])(
+    'preserves @page margin shorthand with %s in adapter-facing stylesheet statements',
+    async (_label, margin) => {
+      let receivedStatements: readonly StylesheetStatement[] = [];
+
+      class StyleCaptureAdapter implements IDocumentConverter {
+        async convert(
+          _parsed: unknown,
+          stylesheet?: IStylesheet
+        ): Promise<Buffer> {
+          receivedStatements = stylesheet?.getStatements() ?? [];
+          return Buffer.from('ok');
+        }
+      }
+
+      const converter = init({
+        domParser: new JSDOMParser(),
+        plugins: [cssParserPlugin()],
+        adapters: {
+          register: [
+            {
+              format: 'style-capture',
+              adapter: StyleCaptureAdapter,
+            },
+          ],
+        },
+      });
+
+      await converter.convert(
+        `<style>@page { margin: ${margin}; }</style><p>Hello</p>`,
+        'style-capture'
+      );
+
+      expect(receivedStatements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'at-rule',
+            name: 'page',
+            descriptors: { margin },
+          }),
+        ])
+      );
+    }
+  );
+
+  it('preserves both @page margin shorthand and longhand descriptors in adapter-facing stylesheet statements', async () => {
+    let receivedStatements: readonly StylesheetStatement[] = [];
+
+    class StyleCaptureAdapter implements IDocumentConverter {
+      async convert(
+        _parsed: unknown,
+        stylesheet?: IStylesheet
+      ): Promise<Buffer> {
+        receivedStatements = stylesheet?.getStatements() ?? [];
+        return Buffer.from('ok');
+      }
+    }
+
+    const converter = init({
+      domParser: new JSDOMParser(),
+      plugins: [cssParserPlugin()],
+      adapters: {
+        register: [
+          {
+            format: 'style-capture',
+            adapter: StyleCaptureAdapter,
+          },
+        ],
+      },
+    });
+
+    await converter.convert(
+      [
+        '<style>',
+        '@page { margin: 1cm 2cm 3cm 4cm; margin-top: 5cm; margin-left: 6cm; }',
+        '</style>',
+        '<p>Hello</p>',
+      ].join(''),
+      'style-capture'
+    );
+
+    expect(receivedStatements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'at-rule',
+          name: 'page',
+          descriptors: {
+            margin: '1cm 2cm 3cm 4cm',
+            marginTop: '5cm',
+            marginLeft: '6cm',
+          },
+        }),
+      ])
+    );
+  });
+
   it('applies element selector + class + class in specificity and source order', async () => {
     const converter = createDocxConverter();
 
@@ -180,5 +323,44 @@ describe('e2e tests for the css parser plugin', () => {
     expect(runProps).toHaveProperty('w:i');
     expect(runProps).toHaveProperty('w:b');
     expect(runProps['w:color']['@_w:val']).toBe('FF3366');
+  });
+
+  it('applies multi-value @page margin shorthand through docx conversion', async () => {
+    const converter = createDocxConverter();
+
+    const docx = await converter.convert(
+      '<style>@page { margin: 1cm 2cm; }</style><p>Page margins</p>',
+      'docx'
+    );
+
+    const documentJson = await parseDocxDocument(docx);
+    const sectionProps = documentJson['w:document']['w:body']['w:sectPr'];
+
+    expect(sectionProps['w:pgMar']['@_w:top']).toBe('567');
+    expect(sectionProps['w:pgMar']['@_w:right']).toBe('1134');
+    expect(sectionProps['w:pgMar']['@_w:bottom']).toBe('567');
+    expect(sectionProps['w:pgMar']['@_w:left']).toBe('1134');
+  });
+
+  it('lets @page longhand margins override shorthand values through docx conversion', async () => {
+    const converter = createDocxConverter();
+
+    const docx = await converter.convert(
+      [
+        '<style>',
+        '@page { margin: 1cm 2cm 3cm 4cm; margin-top: 5cm; margin-left: 6cm; }',
+        '</style>',
+        '<p>Page margins</p>',
+      ].join(''),
+      'docx'
+    );
+
+    const documentJson = await parseDocxDocument(docx);
+    const sectionProps = documentJson['w:document']['w:body']['w:sectPr'];
+
+    expect(sectionProps['w:pgMar']['@_w:top']).toBe('2835');
+    expect(sectionProps['w:pgMar']['@_w:right']).toBe('1134');
+    expect(sectionProps['w:pgMar']['@_w:bottom']).toBe('1701');
+    expect(sectionProps['w:pgMar']['@_w:left']).toBe('3402');
   });
 });


### PR DESCRIPTION
This PR adds tests and a fix in docx adapter where it will use the correct stylesheet