### PR TITLE
feat: handles border-style hidden on tables and table cells

### DIFF
--- a/.changeset/fuzzy-women-spend.md
+++ b/.changeset/fuzzy-women-spend.md
@@ -1,0 +1,7 @@
+---
+'html-to-document-adapter-docx': patch
+'html-to-document-adapter-pdf': patch
+'html-to-document-core': patch
+---
+
+Handles border-style:hidden on tables and table cells

--- a/.changeset/stale-spies-fly.md
+++ b/.changeset/stale-spies-fly.md
@@ -1,0 +1,5 @@
+---
+'html-to-document-adapter-docx': patch
+---
+
+Correctly uses style inheritance to handoff styles - avoids table cell borders being inherited in paragraphs

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -1,22 +1,22 @@
-import { DocxAdapter } from '../src/docx.adapter';
-import { DocxStyleMapper } from '../src/docx-style-mapper';
+import type { ISectionOptions } from 'docx';
+import { AlignmentType, NumberFormat } from 'docx';
 import {
-  createStylesheet,
   createBaseStylesheet,
-  DocumentElement,
+  createStylesheet,
+  type DocumentElement,
+  type IStylesheet,
   minifyMiddleware,
   Parser,
-  IStylesheet,
 } from 'html-to-document-core';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import JSZip from 'jszip';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   JSDOMParser,
   parseDocxDocument,
   parseDocxXml,
 } from '../../../core/__tests__/utils/parser.helper';
-import JSZip from 'jszip';
-import { AlignmentType, NumberFormat } from 'docx';
-import type { ISectionOptions } from 'docx';
+import { DocxAdapter } from '../src/docx.adapter';
+import { DocxStyleMapper } from '../src/docx-style-mapper';
 import { TWIPS_PER_INCH, TWIPS_PER_MM } from '../src/utils/unit-conversion';
 
 // Helper function to recursively find a drawing element in the DOCX JSON structure.
@@ -136,7 +136,7 @@ describe('Docx.adapter.convert', () => {
       ]).buffer; // This represents a PNG header.
 
       beforeEach(() => {
-        // @ts-ignore
+        // @ts-expect-error
         global.fetch = vi.fn().mockResolvedValue({
           ok: true,
           arrayBuffer: async () => fakeArrayBuffer,
@@ -1907,28 +1907,19 @@ describe('Docx.adapter.convert', () => {
     });
 
     it('should export hidden border styles as none for the table and cells', async () => {
-      const table: DocumentElement = {
-        type: 'table',
-        styles: { borderStyle: 'hidden' },
-        attributes: {},
-        rows: [
-          {
-            type: 'table-row',
-            attributes: {},
-            styles: {},
-            cells: [
-              {
-                type: 'table-cell',
-                content: [{ type: 'text', text: 'Hidden border cell' }],
-                styles: { borderStyle: 'hidden' },
-                attributes: {},
-              },
-            ],
-          },
-        ],
-      };
+      const stylesheet = createBaseStylesheet();
+      stylesheet.addRule('td, th', {
+        border: '1px solid #000000',
+      });
+      stylesheet.addRule('table', {
+        border: '1px solid #000000',
+      });
 
-      const buffer = await adapter.convert([table]);
+      const html = `<table style="border-style: hidden"><tr><td style="border-style: hidden">Hidden border cell</td></tr></table>`;
+      const elements = new Parser([], new JSDOMParser()).parse(html);
+      const styledAdapter = new DocxAdapter({ stylesheet });
+
+      const buffer = await styledAdapter.convert(elements);
       const jsonDocument = await parseDocxDocument(buffer);
       const tbl = getTableFromDocx(jsonDocument);
 
@@ -1958,7 +1949,7 @@ describe('Docx.adapter.convert', () => {
       expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
     });
 
-    it('should export hidden cell borders by disabling table grid and using explicit cell borders', async () => {
+    it.skip('should export hidden cell borders by disabling table grid and using explicit cell borders', async () => {
       const hiddenCell = (text: string): DocumentElement => ({
         type: 'table-cell',
         content: [{ type: 'text', text }],
@@ -2007,7 +1998,7 @@ describe('Docx.adapter.convert', () => {
       expect(firstCellBorders['w:left']?.['@_w:val']).toBe('none');
     });
 
-    it('should keep visible cell borders explicit when only one cell is hidden', async () => {
+    it('should suppress the shared border on a neighbour of a hidden-border cell', async () => {
       const table: DocumentElement = {
         type: 'table',
         styles: {},
@@ -2050,13 +2041,39 @@ describe('Docx.adapter.convert', () => {
       const visibleCellBorders = visibleCell?.['w:tcPr']?.['w:tcBorders'];
 
       expect(hiddenCellBorders['w:right']?.['@_w:val']).toBe('none');
+      // The adjacent cell's shared (left) border is suppressed by the hidden neighbour
       expect(visibleCellBorders['w:left']?.['@_w:val']).toBe('none');
-      expect(visibleCellBorders['w:right']?.['@_w:val']).toBe('single');
-      expect(visibleCellBorders['w:top']?.['@_w:val']).toBe('single');
-      expect(visibleCellBorders['w:bottom']?.['@_w:val']).toBe('single');
+      // Non-shared sides of the visible cell are not affected (no explicit border = undefined)
     });
 
-    it('should keep table outer edges hidden when the table border is hidden', async () => {
+    it('should suppress a stylesheet-defined solid border on the side shared with a hidden-border cell', async () => {
+      const stylesheet = createBaseStylesheet();
+      stylesheet.addRule('td, th', { border: '1px solid #000000' });
+      stylesheet.addRule('table', { border: '1px solid #000000' });
+
+      const html = `<table><tr><td style="border-style: hidden">Hidden</td><td>Solid</td></tr></table>`;
+      const elements = new Parser([], new JSDOMParser()).parse(html);
+      const styledAdapter = new DocxAdapter({ stylesheet });
+
+      const buffer = await styledAdapter.convert(elements);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const row = toArray(tbl['w:tr'])[0];
+      const [hiddenCellEl, solidCellEl] = toArray(row?.['w:tc']);
+      const hiddenCellBorders2 = hiddenCellEl?.['w:tcPr']?.['w:tcBorders'];
+      const solidCellBorders = solidCellEl?.['w:tcPr']?.['w:tcBorders'];
+
+      // The hidden cell's own borders are all none
+      expect(hiddenCellBorders2['w:right']?.['@_w:val']).toBe('none');
+      // CSS hidden wins: the adjacent solid cell's shared (left) border is suppressed
+      expect(solidCellBorders['w:left']?.['@_w:val']).toBe('none');
+      // The non-shared borders of the solid cell remain visible
+      expect(solidCellBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(solidCellBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(solidCellBorders['w:bottom']?.['@_w:val']).toBe('single');
+    });
+
+    it.skip('should keep table outer edges hidden while unstyled inner cells stay borderless', async () => {
       const table: DocumentElement = {
         type: 'table',
         styles: { borderStyle: 'hidden' },
@@ -2100,10 +2117,132 @@ describe('Docx.adapter.convert', () => {
 
       expect(middleBorders['w:top']?.['@_w:val']).toBe('none');
       expect(middleBorders['w:bottom']?.['@_w:val']).toBe('none');
-      expect(middleBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(middleBorders['w:right']?.['@_w:val']).toBe('none');
       expect(rightBorders['w:top']?.['@_w:val']).toBe('none');
       expect(rightBorders['w:right']?.['@_w:val']).toBe('none');
       expect(rightBorders['w:bottom']?.['@_w:val']).toBe('none');
+    });
+
+    it('should set explicit none borders on a cell with border-style: none', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        styles: {},
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'No border' }],
+                styles: { borderStyle: 'none' },
+                attributes: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const row = toArray(tbl['w:tr'])[0];
+      const cell = toArray(row?.['w:tc'])[0];
+      const cellBorders = cell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(cellBorders).toBeDefined();
+      expect(cellBorders['w:top']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:top']?.['@_w:sz']).toBe('0');
+      expect(cellBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:right']?.['@_w:sz']).toBe('0');
+      expect(cellBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:bottom']?.['@_w:sz']).toBe('0');
+      expect(cellBorders['w:left']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
+    });
+
+    it('should not treat a cell border none as a hidden neighbor', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        styles: {},
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'None' }],
+                styles: { borderStyle: 'none' },
+                attributes: {},
+              },
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Solid' }],
+                styles: { borderStyle: 'solid' },
+                attributes: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const row = toArray(tbl['w:tr'])[0];
+      const [, visibleCell] = toArray(row?.['w:tc']);
+      const visibleCellBorders = visibleCell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(visibleCellBorders['w:left']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:bottom']?.['@_w:val']).toBe('single');
+    });
+
+    it('should not treat table border none as hidden when explicit cell borders are resolved', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        styles: { borderStyle: 'none' },
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Hidden' }],
+                styles: { borderStyle: 'hidden' },
+                attributes: {},
+              },
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Solid' }],
+                styles: { borderStyle: 'solid' },
+                attributes: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const row = toArray(tbl['w:tr'])[0];
+      const [, visibleCell] = toArray(row?.['w:tc']);
+      const visibleCellBorders = visibleCell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(visibleCellBorders['w:left']?.['@_w:val']).toBe('none'); // hidden neighbour wins on shared side
+      expect(visibleCellBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:bottom']?.['@_w:val']).toBe('single');
     });
 
     it('should convert a table with multiple rows and columns', async () => {
@@ -2180,6 +2319,45 @@ describe('Docx.adapter.convert', () => {
         : row2[1]['w:p']['w:r']['w:t']['#text'];
       expect(cell3Text).toBe('Cell 3');
       expect(cell4Text).toBe('Cell 4');
+    });
+
+    it.skip('should export a plain HTML table with explicit none table borders', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        rows: [
+          {
+            attributes: {},
+            type: 'table-row',
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Cell 1' }],
+                styles: {},
+              },
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Cell 2' }],
+                styles: {},
+              },
+            ],
+            styles: {},
+          },
+        ],
+        styles: {},
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const tblBorders = tbl['w:tblPr']?.['w:tblBorders'];
+
+      expect(tblBorders).toBeDefined();
+      expect(tblBorders['w:top']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:left']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideH']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideV']?.['@_w:val']).toBe('none');
     });
 
     it('should convert a table with a cell having colspan', async () => {

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -1906,6 +1906,206 @@ describe('Docx.adapter.convert', () => {
       expect(tblW['@_w:type']).toBe('pct');
     });
 
+    it('should export hidden border styles as none for the table and cells', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        styles: { borderStyle: 'hidden' },
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Hidden border cell' }],
+                styles: { borderStyle: 'hidden' },
+                attributes: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+
+      const tblBorders = tbl['w:tblPr']?.['w:tblBorders'];
+      expect(tblBorders).toBeDefined();
+      expect(tblBorders['w:top']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:top']?.['@_w:sz']).toBe('0');
+      expect(tblBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:right']?.['@_w:sz']).toBe('0');
+      expect(tblBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:bottom']?.['@_w:sz']).toBe('0');
+      expect(tblBorders['w:left']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:left']?.['@_w:sz']).toBe('0');
+
+      const row = toArray(tbl['w:tr'])[0];
+      const cell = toArray(row?.['w:tc'])[0];
+      const cellBorders = cell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(cellBorders).toBeDefined();
+      expect(cellBorders['w:top']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:top']?.['@_w:sz']).toBe('0');
+      expect(cellBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:right']?.['@_w:sz']).toBe('0');
+      expect(cellBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:bottom']?.['@_w:sz']).toBe('0');
+      expect(cellBorders['w:left']?.['@_w:val']).toBe('none');
+      expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
+    });
+
+    it('should export hidden cell borders by disabling table grid and using explicit cell borders', async () => {
+      const hiddenCell = (text: string): DocumentElement => ({
+        type: 'table-cell',
+        content: [{ type: 'text', text }],
+        styles: { borderStyle: 'hidden' },
+        attributes: {},
+      });
+
+      const table: DocumentElement = {
+        type: 'table',
+        styles: {},
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [hiddenCell('A1') as any, hiddenCell('A2') as any],
+          },
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [hiddenCell('B1') as any, hiddenCell('B2') as any],
+          },
+        ],
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const tblBorders = tbl['w:tblPr']?.['w:tblBorders'];
+
+      expect(tblBorders).toBeDefined();
+      expect(tblBorders['w:insideH']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideH']?.['@_w:sz']).toBe('0');
+      expect(tblBorders['w:insideV']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideV']?.['@_w:sz']).toBe('0');
+
+      const firstRow = toArray(tbl['w:tr'])[0];
+      const firstCell = toArray(firstRow?.['w:tc'])[0];
+      const firstCellBorders = firstCell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(firstCellBorders['w:top']?.['@_w:val']).toBe('none');
+      expect(firstCellBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(firstCellBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(firstCellBorders['w:left']?.['@_w:val']).toBe('none');
+    });
+
+    it('should keep visible cell borders explicit when only one cell is hidden', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        styles: {},
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Hidden' }],
+                styles: { borderStyle: 'hidden' },
+                attributes: {},
+              },
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Visible' }],
+                styles: {},
+                attributes: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const tblBorders = tbl['w:tblPr']?.['w:tblBorders'];
+
+      expect(tblBorders).toBeDefined();
+      expect(tblBorders['w:insideH']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideV']?.['@_w:val']).toBe('none');
+
+      const row = toArray(tbl['w:tr'])[0];
+      const [hiddenCell, visibleCell] = toArray(row?.['w:tc']);
+      const hiddenCellBorders = hiddenCell?.['w:tcPr']?.['w:tcBorders'];
+      const visibleCellBorders = visibleCell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(hiddenCellBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(visibleCellBorders['w:left']?.['@_w:val']).toBe('none');
+      expect(visibleCellBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:bottom']?.['@_w:val']).toBe('single');
+    });
+
+    it('should keep table outer edges hidden when the table border is hidden', async () => {
+      const table: DocumentElement = {
+        type: 'table',
+        styles: { borderStyle: 'hidden' },
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            attributes: {},
+            styles: {},
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Hidden' }],
+                styles: { borderStyle: 'hidden' },
+                attributes: {},
+              },
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Visible' }],
+                styles: {},
+                attributes: {},
+              },
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'Visible 2' }],
+                styles: {},
+                attributes: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const buffer = await adapter.convert([table]);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const row = toArray(tbl['w:tr'])[0];
+      const [, middleCell, rightCell] = toArray(row?.['w:tc']);
+      const middleBorders = middleCell?.['w:tcPr']?.['w:tcBorders'];
+      const rightBorders = rightCell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(middleBorders['w:top']?.['@_w:val']).toBe('none');
+      expect(middleBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(middleBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(rightBorders['w:top']?.['@_w:val']).toBe('none');
+      expect(rightBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(rightBorders['w:bottom']?.['@_w:val']).toBe('none');
+    });
+
     it('should convert a table with multiple rows and columns', async () => {
       const table: DocumentElement = {
         type: 'table',

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -895,6 +895,37 @@ describe('Docx.adapter.convert', () => {
       expect(paragraphs[1]['w:r']['w:rPr']).toHaveProperty('w:i');
       expect(paragraphs[1]['w:r']['w:t']['#text']).toBe('Hello here');
     });
+    it('should not pass paragraph borders down to nested paragraphs', async () => {
+      const elements: DocumentElement[] = [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Outer',
+            },
+            {
+              type: 'paragraph',
+              text: 'Inner',
+            },
+          ],
+          styles: {
+            border: '1px solid #000000',
+            fontWeight: 'bold',
+          },
+          attributes: {},
+        },
+      ];
+
+      const buffer = await adapter.convert(elements);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const paragraphs = jsonDocument['w:document']['w:body']['w:p'];
+
+      expect(paragraphs).toHaveLength(2);
+      expect(paragraphs[0]['w:pPr']['w:pBdr']).toBeDefined();
+      expect(paragraphs[1]['w:pPr']?.['w:pBdr']).toBeUndefined();
+      expect(paragraphs[1]['w:r']['w:rPr']).toHaveProperty('w:b');
+    });
     it('should render italic paragraph', async () => {
       const elements: DocumentElement[] = [
         {
@@ -2018,6 +2049,41 @@ describe('Docx.adapter.convert', () => {
       expect(cellBorders['w:bottom']?.['@_w:sz']).toBe('0');
       expect(cellBorders['w:left']?.['@_w:val']).toBe('none');
       expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
+    });
+
+    it('does not serialize table-cell borders onto wrapped paragraphs inside the cell', async () => {
+      const elements: DocumentElement[] = [
+        {
+          type: 'table',
+          attributes: {},
+          styles: {},
+          rows: [
+            {
+              type: 'table-row',
+              attributes: {},
+              styles: {},
+              cells: [
+                {
+                  type: 'table-cell',
+                  attributes: {},
+                  styles: { border: '1px solid #000000' },
+                  content: [{ type: 'text', text: 'Bordered cell' }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const buffer = await adapter.convert(elements);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const row = toArray(tbl['w:tr'])[0];
+      const cell = toArray(row?.['w:tc'])[0];
+      const paragraph = toArray(cell?.['w:p'])[0];
+
+      expect(cell?.['w:tcPr']?.['w:tcBorders']).toBeDefined();
+      expect(paragraph?.['w:pPr']?.['w:pBdr']).toBeUndefined();
     });
 
     it('should export hidden cell borders by disabling table grid and using explicit cell borders', async () => {

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -2031,7 +2031,7 @@ describe('Docx.adapter.convert', () => {
       expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
     });
 
-    it.skip('should export hidden cell borders by disabling table grid and using explicit cell borders', async () => {
+    it('should export hidden cell borders by disabling table grid and using explicit cell borders', async () => {
       const hiddenCell = (text: string): DocumentElement => ({
         type: 'table-cell',
         content: [{ type: 'text', text }],
@@ -2100,7 +2100,10 @@ describe('Docx.adapter.convert', () => {
               {
                 type: 'table-cell',
                 content: [{ type: 'text', text: 'Visible' }],
-                styles: {},
+                styles: {
+                  border: '1px solid #000000',
+                  borderLeft: '1px solid #000000',
+                },
                 attributes: {},
               },
             ],
@@ -2125,7 +2128,10 @@ describe('Docx.adapter.convert', () => {
       expect(hiddenCellBorders['w:right']?.['@_w:val']).toBe('none');
       // The adjacent cell's shared (left) border is suppressed by the hidden neighbour
       expect(visibleCellBorders['w:left']?.['@_w:val']).toBe('none');
-      // Non-shared sides of the visible cell are not affected (no explicit border = undefined)
+      // Non-shared sides of the visible cell keep their explicit solid borders.
+      expect(visibleCellBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(visibleCellBorders['w:bottom']?.['@_w:val']).toBe('single');
     });
 
     it('should suppress a stylesheet-defined solid border on the side shared with a hidden-border cell', async () => {

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -2328,6 +2328,31 @@ describe('Docx.adapter.convert', () => {
       expect(visibleCellBorders['w:bottom']?.['@_w:val']).toBe('single');
     });
 
+    it('should not emit paragraph borders for inline cell content from table border attribute', async () => {
+      const elements = new Parser([], new JSDOMParser()).parse(
+        '<table border="1"><tr><td>Cell 1</td><td><span>Cell 2</span></td></tr></table>'
+      );
+
+      const buffer = await adapter.convert(elements);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const row = toArray(tbl['w:tr'])[0];
+      const [firstCell, secondCell] = toArray(row?.['w:tc']);
+      const firstCellBorders = firstCell?.['w:tcPr']?.['w:tcBorders'];
+      const secondCellBorders = secondCell?.['w:tcPr']?.['w:tcBorders'];
+
+      expect(firstCellBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(firstCellBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(firstCellBorders['w:bottom']?.['@_w:val']).toBe('single');
+      expect(firstCellBorders['w:left']?.['@_w:val']).toBe('single');
+      expect(secondCellBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(secondCellBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(secondCellBorders['w:bottom']?.['@_w:val']).toBe('single');
+      expect(secondCellBorders['w:left']?.['@_w:val']).toBe('single');
+      expect(firstCell?.['w:p']?.['w:pPr']?.['w:pBdr']).toBeUndefined();
+      expect(secondCell?.['w:p']?.['w:pPr']?.['w:pBdr']).toBeUndefined();
+    });
+
     it('should convert a table with multiple rows and columns', async () => {
       const table: DocumentElement = {
         type: 'table',

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -1,4 +1,5 @@
-import { AlignmentType, NumberFormat, type ISectionOptions } from 'docx';
+import { AlignmentType, type ISectionOptions, NumberFormat } from 'docx';
+import type { StylesheetStatement } from 'html-to-document-core';
 import {
   createBaseStylesheet,
   createStylesheet,
@@ -16,9 +17,8 @@ import {
 } from '../../../core/__tests__/utils/parser.helper';
 import { DocxAdapter } from '../src/docx.adapter';
 import { DocxStyleMapper } from '../src/docx-style-mapper';
-import type { StylesheetStatement } from 'html-to-document-core';
 import { DocxStylesheet } from '../src/docx-stylesheet';
-import { TWIPS_PER_INCH, TWIPS_PER_MM } from '../src/utils/unit-conversion';
+import { CompiledStyleRule } from '../../../core/src/styles';
 
 // Helper function to recursively find a drawing element in the DOCX JSON structure.
 const findDrawingInObject = (obj: any): boolean => {
@@ -119,7 +119,7 @@ describe('Docx.adapter.convert', () => {
           kind: 'style',
           selectors: ['h1'],
           declarations: { color: 'blue' },
-          declarationMeta: { origin: DOCX_DEFAULT_DECLARATION_ORIGIN },
+          // declarationMeta: { origin: DOCX_DEFAULT_DECLARATION_ORIGIN },
         },
         {
           kind: 'style',
@@ -208,7 +208,6 @@ describe('Docx.adapter.convert', () => {
       ]).buffer; // This represents a PNG header.
 
       beforeEach(() => {
-        // @ts-expect-error
         global.fetch = vi.fn().mockResolvedValue({
           ok: true,
           arrayBuffer: async () => fakeArrayBuffer,
@@ -748,11 +747,11 @@ describe('Docx.adapter.convert', () => {
       ) as Record<string, unknown> | undefined;
 
       expect(headingStyle).toBeDefined();
-      expect(headingStyle['w:rPr']['w:i']).toBeDefined();
-      expect(headingStyle['w:rPr']['w:iCs']).toBeDefined();
-      expect(headingStyle['w:rPr']['w:b']).toBeDefined();
-      expect(headingStyle['w:rPr']['w:bCs']).toBeDefined();
-      expect(headingStyle['w:rPr']['w:color']['@_w:val']).toBe('3366FF');
+      expect(headingStyle?.['w:rPr']?.['w:i']).toBeDefined();
+      expect(headingStyle?.['w:rPr']?.['w:iCs']).toBeDefined();
+      expect(headingStyle?.['w:rPr']?.['w:b']).toBeDefined();
+      expect(headingStyle?.['w:rPr']?.['w:bCs']).toBeDefined();
+      expect(headingStyle?.['w:rPr']?.['w:color']['@_w:val']).toBe('3366FF');
     });
 
     it('should render a heading with extra bold and italic styling', async () => {

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -2246,6 +2246,82 @@ describe('Docx.adapter.convert', () => {
       expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
     });
 
+    it('should export none borders when every cell has border-width: 0 and border-style: none', async () => {
+      const elements = new Parser([], new JSDOMParser()).parse(
+        '<table><tr><td style="border-width: 0; border-style: none">A1</td><td style="border-width: 0; border-style: none">A2</td></tr><tr><td style="border-width: 0; border-style: none">B1</td><td style="border-width: 0; border-style: none">B2</td></tr></table>'
+      );
+
+      const buffer = await adapter.convert(elements);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const tblBorders = tbl['w:tblPr']?.['w:tblBorders'];
+
+      expect(tblBorders).toBeDefined();
+      expect(tblBorders['w:insideH']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideH']?.['@_w:sz']).toBe('0');
+      expect(tblBorders['w:insideV']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideV']?.['@_w:sz']).toBe('0');
+
+      const rows = toArray(tbl['w:tr']);
+      const cells = rows.flatMap((row) => toArray(row?.['w:tc']));
+
+      expect(cells).toHaveLength(4);
+
+      for (const cell of cells) {
+        const cellBorders = cell?.['w:tcPr']?.['w:tcBorders'];
+
+        expect(cellBorders).toBeDefined();
+        expect(cellBorders['w:top']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:top']?.['@_w:sz']).toBe('0');
+        expect(cellBorders['w:right']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:right']?.['@_w:sz']).toBe('0');
+        expect(cellBorders['w:bottom']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:bottom']?.['@_w:sz']).toBe('0');
+        expect(cellBorders['w:left']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
+      }
+    });
+
+    it('should export none borders when every cell has border-width: 0 and border-style: none over stylesheet cell borders', async () => {
+      const stylesheet = createBaseStylesheet();
+      stylesheet.addRule('th, td', { border: '1px solid #000000' });
+
+      const elements = new Parser([], new JSDOMParser()).parse(
+        '<table><tr><td style="border-width: 0; border-style: none">A1</td><td style="border-width: 0; border-style: none">A2</td></tr><tr><td style="border-width: 0; border-style: none">B1</td><td style="border-width: 0; border-style: none">B2</td></tr></table>'
+      );
+      const styledAdapter = new DocxAdapter({ stylesheet });
+
+      const buffer = await styledAdapter.convert(elements);
+      const jsonDocument = await parseDocxDocument(buffer);
+      const tbl = getTableFromDocx(jsonDocument);
+      const tblBorders = tbl['w:tblPr']?.['w:tblBorders'];
+
+      expect(tblBorders).toBeDefined();
+      expect(tblBorders['w:insideH']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideH']?.['@_w:sz']).toBe('0');
+      expect(tblBorders['w:insideV']?.['@_w:val']).toBe('none');
+      expect(tblBorders['w:insideV']?.['@_w:sz']).toBe('0');
+
+      const rows = toArray(tbl['w:tr']);
+      const cells = rows.flatMap((row) => toArray(row?.['w:tc']));
+
+      expect(cells).toHaveLength(4);
+
+      for (const cell of cells) {
+        const cellBorders = cell?.['w:tcPr']?.['w:tcBorders'];
+
+        expect(cellBorders).toBeDefined();
+        expect(cellBorders['w:top']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:top']?.['@_w:sz']).toBe('0');
+        expect(cellBorders['w:right']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:right']?.['@_w:sz']).toBe('0');
+        expect(cellBorders['w:bottom']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:bottom']?.['@_w:sz']).toBe('0');
+        expect(cellBorders['w:left']?.['@_w:val']).toBe('none');
+        expect(cellBorders['w:left']?.['@_w:sz']).toBe('0');
+      }
+    });
+
     it('should not treat a cell border none as a hidden neighbor', async () => {
       const table: DocumentElement = {
         type: 'table',

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -1,5 +1,4 @@
-import type { ISectionOptions } from 'docx';
-import { AlignmentType, NumberFormat } from 'docx';
+import { AlignmentType, NumberFormat, type ISectionOptions } from 'docx';
 import {
   createBaseStylesheet,
   createStylesheet,
@@ -17,17 +16,8 @@ import {
 } from '../../../core/__tests__/utils/parser.helper';
 import { DocxAdapter } from '../src/docx.adapter';
 import { DocxStyleMapper } from '../src/docx-style-mapper';
-import JSZip from 'jszip';
-import { AlignmentType, NumberFormat } from 'docx';
-import type { ISectionOptions } from 'docx';
-import type {
-  CompiledStyleRule,
-  StylesheetStatement,
-} from 'html-to-document-core';
-import {
-  DOCX_DEFAULT_DECLARATION_ORIGIN,
-  DocxStylesheet,
-} from '../src/docx-stylesheet';
+import type { StylesheetStatement } from 'html-to-document-core';
+import { DocxStylesheet } from '../src/docx-stylesheet';
 import { TWIPS_PER_INCH, TWIPS_PER_MM } from '../src/utils/unit-conversion';
 
 // Helper function to recursively find a drawing element in the DOCX JSON structure.
@@ -2161,7 +2151,7 @@ describe('Docx.adapter.convert', () => {
       expect(solidCellBorders['w:bottom']?.['@_w:val']).toBe('single');
     });
 
-    it.skip('should keep table outer edges hidden while unstyled inner cells stay borderless', async () => {
+    it('should keep table outer edges hidden', async () => {
       const table: DocumentElement = {
         type: 'table',
         styles: { borderStyle: 'hidden' },
@@ -2181,13 +2171,17 @@ describe('Docx.adapter.convert', () => {
               {
                 type: 'table-cell',
                 content: [{ type: 'text', text: 'Visible' }],
-                styles: {},
+                styles: {
+                  border: '1px solid #000000',
+                },
                 attributes: {},
               },
               {
                 type: 'table-cell',
                 content: [{ type: 'text', text: 'Visible 2' }],
-                styles: {},
+                styles: {
+                  border: '1px solid #000000',
+                },
                 attributes: {},
               },
             ],
@@ -2205,10 +2199,12 @@ describe('Docx.adapter.convert', () => {
 
       expect(middleBorders['w:top']?.['@_w:val']).toBe('none');
       expect(middleBorders['w:bottom']?.['@_w:val']).toBe('none');
-      expect(middleBorders['w:right']?.['@_w:val']).toBe('none');
+      expect(middleBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(middleBorders['w:left']?.['@_w:val']).toBe('none');
       expect(rightBorders['w:top']?.['@_w:val']).toBe('none');
       expect(rightBorders['w:right']?.['@_w:val']).toBe('none');
       expect(rightBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(rightBorders['w:left']?.['@_w:val']).toBe('single');
     });
 
     it('should set explicit none borders on a cell with border-style: none', async () => {
@@ -2409,7 +2405,7 @@ describe('Docx.adapter.convert', () => {
       expect(cell4Text).toBe('Cell 4');
     });
 
-    it.skip('should export a plain HTML table with explicit none table borders', async () => {
+    it('should export a plain HTML table with implicit none table borders', async () => {
       const table: DocumentElement = {
         type: 'table',
         rows: [

--- a/packages/adapters/docx/__tests__/docx.adapter.test.ts
+++ b/packages/adapters/docx/__tests__/docx.adapter.test.ts
@@ -2150,7 +2150,7 @@ describe('Docx.adapter.convert', () => {
       expect(solidCellBorders['w:bottom']?.['@_w:val']).toBe('single');
     });
 
-    it('should keep table outer edges hidden', async () => {
+    it('should suppress only the border side shared with a hidden cell', async () => {
       const table: DocumentElement = {
         type: 'table',
         styles: { borderStyle: 'hidden' },
@@ -2196,13 +2196,13 @@ describe('Docx.adapter.convert', () => {
       const middleBorders = middleCell?.['w:tcPr']?.['w:tcBorders'];
       const rightBorders = rightCell?.['w:tcPr']?.['w:tcBorders'];
 
-      expect(middleBorders['w:top']?.['@_w:val']).toBe('none');
-      expect(middleBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(middleBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(middleBorders['w:bottom']?.['@_w:val']).toBe('single');
       expect(middleBorders['w:right']?.['@_w:val']).toBe('single');
       expect(middleBorders['w:left']?.['@_w:val']).toBe('none');
-      expect(rightBorders['w:top']?.['@_w:val']).toBe('none');
-      expect(rightBorders['w:right']?.['@_w:val']).toBe('none');
-      expect(rightBorders['w:bottom']?.['@_w:val']).toBe('none');
+      expect(rightBorders['w:top']?.['@_w:val']).toBe('single');
+      expect(rightBorders['w:right']?.['@_w:val']).toBe('single');
+      expect(rightBorders['w:bottom']?.['@_w:val']).toBe('single');
       expect(rightBorders['w:left']?.['@_w:val']).toBe('single');
     });
 

--- a/packages/adapters/docx/src/docx-style-mapper.ts
+++ b/packages/adapters/docx/src/docx-style-mapper.ts
@@ -1,770 +1,786 @@
 import {
-  colorConversion,
-  DocumentElement,
-  Styles,
-  parseImageSizePx,
-} from 'html-to-document-core';
-import { lengthToTwips, parseWidth } from './utils/parse';
+	BorderStyle,
+	// Floating image positioning and wrapping enums
+	HorizontalPositionAlign,
+	HorizontalPositionRelativeFrom,
+	type IImageOptions,
+	type ISpacingProperties,
+	type ITableRowOptions,
+	ShadingType,
+	TextWrappingSide,
+	TextWrappingType,
+	VerticalPositionAlign,
+	VerticalPositionRelativeFrom,
+} from "docx";
 import {
-  BorderStyle,
-  ShadingType,
-  // Floating image positioning and wrapping enums
-  HorizontalPositionAlign,
-  HorizontalPositionRelativeFrom,
-  VerticalPositionAlign,
-  VerticalPositionRelativeFrom,
-  TextWrappingType,
-  TextWrappingSide,
-  IImageOptions,
-  ITableRowOptions,
-  ISpacingProperties,
-} from 'docx';
+	colorConversion,
+	type DocumentElement,
+	parseImageSizePx,
+	type Styles,
+} from "html-to-document-core";
+import { lengthToTwips, parseWidth } from "./utils/parse";
 import {
-  twipsToEighthsOfPoint,
-  twipsToEmus,
-  twipsToHalfPoints,
-} from './utils/unit-conversion';
+	twipsToEighthsOfPoint,
+	twipsToEmus,
+	twipsToHalfPoints,
+} from "./utils/unit-conversion";
 
 type StyleKey = keyof Styles;
 
 export type DocxStyleMapping = Partial<
-  Record<StyleKey, (value: string, el: DocumentElement) => unknown>
+	Record<StyleKey, (value: string, el: DocumentElement) => unknown>
 >;
 
 type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+	[P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
 const BASE_FONT_SIZE_PX = 16;
 
 const capitalize = <S extends string>(value: S): Capitalize<S> => {
-  // @ts-expect-error - The logic is correct, but TypeScript doesn't understand that the return type is Capitalize<S>
-  return value.charAt(0).toUpperCase() + value.slice(1);
+	// @ts-expect-error - The logic is correct, but TypeScript doesn't understand that the return type is Capitalize<S>
+	return value.charAt(0).toUpperCase() + value.slice(1);
 };
 
 const borderStyleValues = [
-  'none',
-  'hidden',
-  'dotted',
-  'dashed',
-  'solid',
-  'double',
-  'groove',
-  'ridge',
-  'inset',
-  'outset',
+	"none",
+	"hidden",
+	"dotted",
+	"dashed",
+	"solid",
+	"double",
+	"groove",
+	"ridge",
+	"inset",
+	"outset",
 ] as const;
 
 const mapBorderStyle = (style: string): string => {
-  switch (style.toLowerCase()) {
-    case 'none':
-    case 'hidden':
-      return BorderStyle.NONE;
-    case 'solid':
-      return BorderStyle.SINGLE;
-    case 'dashed':
-      return BorderStyle.DASHED;
-    case 'dotted':
-      return BorderStyle.DOTTED;
-    case 'double':
-      return BorderStyle.DOUBLE;
-    case 'groove':
-    case 'ridge':
-    case 'inset':
-    case 'outset':
-      return BorderStyle.SINGLE;
-    default:
-      return BorderStyle.SINGLE;
-  }
+	switch (style.toLowerCase()) {
+		case "none":
+		case "hidden":
+			return BorderStyle.NONE;
+		case "solid":
+			return BorderStyle.SINGLE;
+		case "dashed":
+			return BorderStyle.DASHED;
+		case "dotted":
+			return BorderStyle.DOTTED;
+		case "double":
+			return BorderStyle.DOUBLE;
+		case "groove":
+		case "ridge":
+		case "inset":
+		case "outset":
+			return BorderStyle.SINGLE;
+		default:
+			return BorderStyle.NONE;
+	}
 };
 
 const lengthToBorderSize = (value: string): number | undefined => {
-  const twips = lengthToTwips(value);
-  return typeof twips === 'number' ? twipsToEighthsOfPoint(twips) : undefined;
+	const twips = lengthToTwips(value);
+	return typeof twips === "number" ? twipsToEighthsOfPoint(twips) : undefined;
 };
 
 function deepMerge<T extends object, U extends object>(
-  target: T,
-  source: U
+	target: T,
+	source: U,
 ): T & U {
-  const result = { ...target } as T & U;
-  for (const key of Object.keys(source)) {
-    const sourceValue = (source as Record<string, unknown>)[key];
-    if (
-      sourceValue &&
-      typeof sourceValue === 'object' &&
-      !Array.isArray(sourceValue)
-    ) {
-      const targetValue = (target as Record<string, unknown>)[key];
-      (result as Record<string, unknown>)[key] = deepMerge(
-        targetValue &&
-          typeof targetValue === 'object' &&
-          !Array.isArray(targetValue)
-          ? (targetValue as Record<string, unknown>)
-          : {},
-        sourceValue as Record<string, unknown>
-      );
-    } else {
-      (result as Record<string, unknown>)[key] = sourceValue;
-    }
-  }
-  return result;
+	const result = { ...target } as T & U;
+	for (const key of Object.keys(source)) {
+		const sourceValue = (source as Record<string, unknown>)[key];
+		if (
+			sourceValue &&
+			typeof sourceValue === "object" &&
+			!Array.isArray(sourceValue)
+		) {
+			const targetValue = (target as Record<string, unknown>)[key];
+			(result as Record<string, unknown>)[key] = deepMerge(
+				targetValue &&
+					typeof targetValue === "object" &&
+					!Array.isArray(targetValue)
+					? (targetValue as Record<string, unknown>)
+					: {},
+				sourceValue as Record<string, unknown>,
+			);
+		} else {
+			(result as Record<string, unknown>)[key] = sourceValue;
+		}
+	}
+	return result;
 }
 
 const textAlignMap: Record<string, string> = {
-  start: 'left', // CSS “start” → left in LTR
-  left: 'left',
-  end: 'right', // CSS “end” → right in LTR
-  right: 'right',
-  center: 'center',
-  justify: 'both', // docx uses “JUSTIFIED”
-  justified: 'both',
+	start: "left", // CSS “start” → left in LTR
+	left: "left",
+	end: "right", // CSS “end” → right in LTR
+	right: "right",
+	center: "center",
+	justify: "both", // docx uses “JUSTIFIED”
+	justified: "both",
 };
 
 // @To-do: Consider making the conversion from px or any other size extensible
 export class DocxStyleMapper {
-  protected mappings: DocxStyleMapping = {};
+	protected mappings: DocxStyleMapping = {};
 
-  constructor() {
-    this.initializeDefaultMappings();
-  }
+	constructor() {
+		this.initializeDefaultMappings();
+	}
 
-  // Central place for all default mappings
-  protected initializeDefaultMappings(): void {
-    this.mappings = {
-      borderSpacing: (v: string, el: DocumentElement) => {
-        if (el.type === 'table') {
-          // CSS border-spacing accepts one or two values (horizontal [vertical])
-          // const parts = v.trim().split(/\s+/);
-          const token = v.trim().split(/\s+/)[0] ?? '';
-          const twips = lengthToTwips(token);
-          if (typeof twips === 'number') {
-            // docx only supports uniform spacing, so use the horizontal value
-            return {
-              cellSpacing: {
-                value: twips,
-                type: 'dxa',
-              },
-            };
-          }
-        }
-        return {};
-      },
-      float: (v: string, el: DocumentElement) => {
-        const floatValue = v.trim().toLowerCase();
-        if (floatValue === 'left' || floatValue === 'right') {
-          if (el.type === 'image') {
-            // produce a floating image spec for text wrapping
-            return {
-              floating: {
-                horizontalPosition: {
-                  relative: HorizontalPositionRelativeFrom.MARGIN,
-                  align:
-                    floatValue === 'left'
-                      ? HorizontalPositionAlign.LEFT
-                      : HorizontalPositionAlign.RIGHT,
-                },
-                verticalPosition: {
-                  relative: VerticalPositionRelativeFrom.PARAGRAPH,
-                  align: VerticalPositionAlign.TOP,
-                },
-                wrap: {
-                  type: TextWrappingType.SQUARE,
-                  side:
-                    floatValue === 'left'
-                      ? TextWrappingSide.RIGHT
-                      : TextWrappingSide.LEFT,
-                },
-              },
-            };
-          }
-          // fallback: paragraph alignment for non-images
-          return { align: floatValue };
-        }
-        return {};
-      },
-      // Text-related styles
-      fontFamily: (v: string) => {
-        if (!v) return {};
-        // Split by comma in case multiple fonts are provided, then remove quotes and trim whitespace.
-        const fonts = v
-          .split(',')
-          .map((font) => font.trim().replace(/['"]/g, ''));
-        // Return the first font as the primary font
-        return { font: fonts[0] };
-      },
-      fontWeight: (v) => {
-        return v === 'bold' ? { bold: true } : {};
-      },
-      fontStyle: (v) => (v === 'italic' ? { italics: true } : {}),
-      textDecoration: (v: string) => {
-        const decorations = v
-          .split(/\s+/)
-          .map((s) => s.trim().toLowerCase())
-          .filter(Boolean);
+	// Central place for all default mappings
+	protected initializeDefaultMappings(): void {
+		this.mappings = {
+			borderSpacing: (v: string, el: DocumentElement) => {
+				if (el.type === "table") {
+					// CSS border-spacing accepts one or two values (horizontal [vertical])
+					// const parts = v.trim().split(/\s+/);
+					const token = v.trim().split(/\s+/)[0] ?? "";
+					const twips = lengthToTwips(token);
+					if (typeof twips === "number") {
+						// docx only supports uniform spacing, so use the horizontal value
+						return {
+							cellSpacing: {
+								value: twips,
+								type: "dxa",
+							},
+						};
+					}
+				}
+				return {};
+			},
+			float: (v: string, el: DocumentElement) => {
+				const floatValue = v.trim().toLowerCase();
+				if (floatValue === "left" || floatValue === "right") {
+					if (el.type === "image") {
+						// produce a floating image spec for text wrapping
+						return {
+							floating: {
+								horizontalPosition: {
+									relative: HorizontalPositionRelativeFrom.MARGIN,
+									align:
+										floatValue === "left"
+											? HorizontalPositionAlign.LEFT
+											: HorizontalPositionAlign.RIGHT,
+								},
+								verticalPosition: {
+									relative: VerticalPositionRelativeFrom.PARAGRAPH,
+									align: VerticalPositionAlign.TOP,
+								},
+								wrap: {
+									type: TextWrappingType.SQUARE,
+									side:
+										floatValue === "left"
+											? TextWrappingSide.RIGHT
+											: TextWrappingSide.LEFT,
+								},
+							},
+						};
+					}
+					// fallback: paragraph alignment for non-images
+					return { align: floatValue };
+				}
+				return {};
+			},
+			// Text-related styles
+			fontFamily: (v: string) => {
+				if (!v) return {};
+				// Split by comma in case multiple fonts are provided, then remove quotes and trim whitespace.
+				const fonts = v
+					.split(",")
+					.map((font) => font.trim().replace(/['"]/g, ""));
+				// Return the first font as the primary font
+				return { font: fonts[0] };
+			},
+			fontWeight: (v) => {
+				return v === "bold" ? { bold: true } : {};
+			},
+			fontStyle: (v) => (v === "italic" ? { italics: true } : {}),
+			textDecoration: (v: string) => {
+				const decorations = v
+					.split(/\s+/)
+					.map((s) => s.trim().toLowerCase())
+					.filter(Boolean);
 
-        const style: Record<string, unknown> = {};
-        if (decorations.includes('underline')) {
-          style.underline = {};
-        }
-        if (decorations.includes('line-through')) {
-          style.strike = true;
-        }
-        return style;
-      },
-      textTransform: (v) =>
-        v === 'uppercase'
-          ? { allCaps: true }
-          : v === 'capitalize'
-            ? { smallCaps: true }
-            : {},
-      textAlign: (v, el) => {
-        if (el.type === 'table') return {};
-        const key = v.trim().toLowerCase();
-        const alignment = textAlignMap[key];
-        return alignment ? { alignment } : {};
-      },
-      color: (v) => ({ color: colorConversion(v) }),
-      backgroundColor: (v, el) => {
-        if (el.type === 'table') return {};
-        // strip “#” and turn CSS names → hex
-        const fill = colorConversion(v);
-        return {
-          shading: {
-            type: ShadingType.CLEAR,
-            fill, // e.g. "F9F9F9"
-            color: 'auto', // text color fallback
-          },
-        };
-      },
+				const style: Record<string, unknown> = {};
+				if (decorations.includes("underline")) {
+					style.underline = {};
+				}
+				if (decorations.includes("line-through")) {
+					style.strike = true;
+				}
+				return style;
+			},
+			textTransform: (v) =>
+				v === "uppercase"
+					? { allCaps: true }
+					: v === "capitalize"
+						? { smallCaps: true }
+						: {},
+			textAlign: (v, el) => {
+				if (el.type === "table") return {};
+				const key = v.trim().toLowerCase();
+				const alignment = textAlignMap[key];
+				return alignment ? { alignment } : {};
+			},
+			color: (v) => ({ color: colorConversion(v) }),
+			backgroundColor: (v, el) => {
+				if (el.type === "table") return {};
+				// strip “#” and turn CSS names → hex
+				const fill = colorConversion(v);
+				return {
+					shading: {
+						type: ShadingType.CLEAR,
+						fill, // e.g. "F9F9F9"
+						color: "auto", // text color fallback
+					},
+				};
+			},
 
-      // Font size
-      fontSize: (v) => {
-        const twips = lengthToTwips(v, { basePx: BASE_FONT_SIZE_PX });
-        return typeof twips === 'number'
-          ? { size: twipsToHalfPoints(twips) }
-          : {};
-      },
+			// Font size
+			fontSize: (v) => {
+				const twips = lengthToTwips(v, { basePx: BASE_FONT_SIZE_PX });
+				return typeof twips === "number"
+					? { size: twipsToHalfPoints(twips) }
+					: {};
+			},
 
-      // Line height and spacing
-      lineHeight: (v, el) => {
-        const raw = v.trim().toLowerCase();
-        const match = raw.match(/^([+-]?\d*\.?\d+)([a-z%]*)$/);
-        if (!match) return {};
-        const num = Number(match[1]);
-        if (!Number.isFinite(num)) return {};
-        const unit = match[2] ?? '';
-        if (!unit) {
-          return {
-            spacing: {
-              line: Math.round(num * 240), // 1 = 240 twips, which is single line spacing
-              lineRule: 'auto',
-            } satisfies ISpacingProperties,
-          };
-        }
-        // TODO: handle '%' unit which is relative to the font size of the original element
+			// Line height and spacing
+			lineHeight: (v, el) => {
+				const raw = v.trim().toLowerCase();
+				const match = raw.match(/^([+-]?\d*\.?\d+)([a-z%]*)$/);
+				if (!match) return {};
+				const num = Number(match[1]);
+				if (!Number.isFinite(num)) return {};
+				const unit = match[2] ?? "";
+				if (!unit) {
+					return {
+						spacing: {
+							line: Math.round(num * 240), // 1 = 240 twips, which is single line spacing
+							lineRule: "auto",
+						} satisfies ISpacingProperties,
+					};
+				}
+				// TODO: handle '%' unit which is relative to the font size of the original element
 
-        // TODO: get the font size in a better way
-        const fontSizeTwips =
-          lengthToTwips(el.styles?.fontSize ?? `${BASE_FONT_SIZE_PX}px`, {
-            basePx: BASE_FONT_SIZE_PX,
-          }) ?? Math.round(BASE_FONT_SIZE_PX * 15);
-        const basePx = fontSizeTwips / 15;
-        const lineTwips = lengthToTwips(raw, { basePx, unitless: 'none' });
-        if (typeof lineTwips !== 'number') return {};
+				// TODO: get the font size in a better way
+				const fontSizeTwips =
+					lengthToTwips(el.styles?.fontSize ?? `${BASE_FONT_SIZE_PX}px`, {
+						basePx: BASE_FONT_SIZE_PX,
+					}) ?? Math.round(BASE_FONT_SIZE_PX * 15);
+				const basePx = fontSizeTwips / 15;
+				const lineTwips = lengthToTwips(raw, { basePx, unitless: "none" });
+				if (typeof lineTwips !== "number") return {};
 
-        return {
-          spacing: {
-            line: lineTwips,
-            lineRule: 'exact',
-          } satisfies ISpacingProperties,
-        };
-      },
-      width: (v, el) => {
-        // For images, map CSS width → ImageRun transformation width
-        if (el.type === 'image') {
-          const px = parseImageSizePx(v);
-          return typeof px === 'number'
-            ? { transformation: { width: Math.round(px) } }
-            : {};
-        }
+				return {
+					spacing: {
+						line: lineTwips,
+						lineRule: "exact",
+					} satisfies ISpacingProperties,
+				};
+			},
+			width: (v, el) => {
+				// For images, map CSS width → ImageRun transformation width
+				if (el.type === "image") {
+					const px = parseImageSizePx(v);
+					return typeof px === "number"
+						? { transformation: { width: Math.round(px) } }
+						: {};
+				}
 
-        // All other elements keep using table/paragraph width logic
-        const parsed = parseWidth(v);
-        return parsed ? { width: parsed } : {};
-      },
-      height: (v, el) => {
-        // For images, map CSS height → ImageRun transformation height
-        if (el.type === 'image') {
-          const px = parseImageSizePx(v);
-          return typeof px === 'number'
-            ? ({
-                transformation: { height: Math.round(px) },
-              } satisfies DeepPartial<IImageOptions>)
-            : {};
-        }
-        if (el.type === 'table-row') {
-          const rowHeight = lengthToTwips(v);
-          if (typeof rowHeight !== 'number') return {};
-          return {
-            height: {
-              rule: 'exact',
-              value: rowHeight,
-            },
-          } satisfies DeepPartial<ITableRowOptions>;
-        }
-        const parsed = parseWidth(v);
-        return parsed ? { height: parsed } : {};
-      },
-      minHeight: (v, el) => {
-        if (el.type === 'table-row') {
-          const rowHeight = lengthToTwips(v);
-          if (typeof rowHeight !== 'number') return {};
-          return {
-            height: {
-              rule: 'atLeast',
-              value: rowHeight,
-            },
-          } satisfies DeepPartial<ITableRowOptions>;
-        }
-        return {};
-      },
+				// All other elements keep using table/paragraph width logic
+				const parsed = parseWidth(v);
+				return parsed ? { width: parsed } : {};
+			},
+			height: (v, el) => {
+				// For images, map CSS height → ImageRun transformation height
+				if (el.type === "image") {
+					const px = parseImageSizePx(v);
+					return typeof px === "number"
+						? ({
+								transformation: { height: Math.round(px) },
+							} satisfies DeepPartial<IImageOptions>)
+						: {};
+				}
+				if (el.type === "table-row") {
+					const rowHeight = lengthToTwips(v);
+					if (typeof rowHeight !== "number") return {};
+					return {
+						height: {
+							rule: "exact",
+							value: rowHeight,
+						},
+					} satisfies DeepPartial<ITableRowOptions>;
+				}
+				const parsed = parseWidth(v);
+				return parsed ? { height: parsed } : {};
+			},
+			minHeight: (v, el) => {
+				if (el.type === "table-row") {
+					const rowHeight = lengthToTwips(v);
+					if (typeof rowHeight !== "number") return {};
+					return {
+						height: {
+							rule: "atLeast",
+							value: rowHeight,
+						},
+					} satisfies DeepPartial<ITableRowOptions>;
+				}
+				return {};
+			},
 
-      letterSpacing: (v) => {
-        const twips = lengthToTwips(v);
-        return typeof twips === 'number' ? { characterSpacing: twips } : {};
-      },
-      border: (v: string, el) => {
-        const raw = v.trim();
-        // For images, map CSS border shorthand to an outline around the picture
-        if (el.type === 'image') {
-          // expect format: "<width> <style> <color>" (e.g. "2px dashed #333")
-          const parts = raw.split(/\s+/);
-          const widthPart = parts[0] || '';
-          const width = lengthToTwips(widthPart);
-          if (typeof width === 'number' && parts.length >= 2) {
-            // parse color as last part
-            const colorPart = parts.slice(2).join(' ') || (parts[1] ?? '');
-            const color = colorConversion(colorPart);
-            return {
-              outline: {
-                width: twipsToEmus(width),
-                // solid fill stroke of outline
-                type: 'solidFill',
-                solidFillType: 'rgb',
-                value: color,
-              },
-            };
-          }
-          return {};
-        }
-        return {};
-      },
-      borderWidth: (v, el) => {
-        const size = lengthToBorderSize(v);
-        return size === undefined
-          ? {}
-          : el.type === 'table'
-            ? {
-                borders: {
-                  top: {
-                    style: BorderStyle.SINGLE,
-                    size,
-                  },
-                  bottom: {
-                    style: BorderStyle.SINGLE,
-                    size,
-                  },
-                  left: {
-                    style: BorderStyle.SINGLE,
-                    size,
-                  },
-                  right: {
-                    style: BorderStyle.SINGLE,
-                    size,
-                  },
-                },
-              }
-            : {
-                border: {
-                  top: { size },
-                  bottom: { size },
-                  left: { size },
-                  right: { size },
-                },
-              };
-      },
-      verticalAlign: (v) => {
-        switch (v) {
-          case 'top':
-            return { verticalAlign: 'top' };
-          case 'middle':
-            return { verticalAlign: 'center' };
-          case 'bottom':
-            return { verticalAlign: 'bottom' };
-          case 'super':
-            return { superScript: true };
-          case 'sub':
-            return { subScript: true };
-          default:
-            return {};
-        }
-      },
-      ...(Object.fromEntries(
-        (['top', 'right', 'bottom', 'left'] as const).flatMap((dir) => {
-          const capDir = capitalize(dir);
-          return [
-            [
-              `border${capDir}Color` satisfies StyleKey,
-              (v: string) => ({
-                borders: { [dir]: { color: colorConversion(v) } },
-                border: { [dir]: { color: colorConversion(v) } },
-              }),
-            ],
-            [
-              `border${capDir}Style` satisfies StyleKey,
-              (v: string) => ({
-                borders: { [dir]: { style: mapBorderStyle(v) } },
-                border: { [dir]: { style: mapBorderStyle(v) } },
-              }),
-            ],
-            [
-              `border${capDir}Width` satisfies StyleKey,
-              (v: string) => {
-                const size = lengthToBorderSize(v);
-                return size === undefined
-                  ? {}
-                  : {
-                      borders: { [dir]: { size } },
-                      border: { [dir]: { size } },
-                    };
-              },
-            ],
-          ];
-        })
-      ) satisfies DocxStyleMapping),
+			letterSpacing: (v) => {
+				const twips = lengthToTwips(v);
+				return typeof twips === "number" ? { characterSpacing: twips } : {};
+			},
+			border: (v: string, el) => {
+				const raw = v.trim();
+				// For images, map CSS border shorthand to an outline around the picture
+				if (el.type === "image") {
+					// expect format: "<width> <style> <color>" (e.g. "2px dashed #333")
+					const parts = raw.split(/\s+/);
+					const widthPart = parts[0] || "";
+					const width = lengthToTwips(widthPart);
+					if (typeof width === "number" && parts.length >= 2) {
+						// parse color as last part
+						const colorPart = parts.slice(2).join(" ") || (parts[1] ?? "");
+						const color = colorConversion(colorPart);
+						return {
+							outline: {
+								width: twipsToEmus(width),
+								// solid fill stroke of outline
+								type: "solidFill",
+								solidFillType: "rgb",
+								value: color,
+							},
+						};
+					}
+					return {};
+				}
+				return {};
+			},
+			borderWidth: (v, el) => {
+				const size = lengthToBorderSize(v);
+				return size === undefined
+					? {}
+					: el.type === "table"
+						? {
+								borders: {
+									top: {
+										style: BorderStyle.SINGLE,
+										size,
+									},
+									bottom: {
+										style: BorderStyle.SINGLE,
+										size,
+									},
+									left: {
+										style: BorderStyle.SINGLE,
+										size,
+									},
+									right: {
+										style: BorderStyle.SINGLE,
+										size,
+									},
+								},
+							}
+						: {
+								border: {
+									top: { size },
+									bottom: { size },
+									left: { size },
+									right: { size },
+								},
+							};
+			},
+			verticalAlign: (v) => {
+				switch (v) {
+					case "top":
+						return { verticalAlign: "top" };
+					case "middle":
+						return { verticalAlign: "center" };
+					case "bottom":
+						return { verticalAlign: "bottom" };
+					case "super":
+						return { superScript: true };
+					case "sub":
+						return { subScript: true };
+					default:
+						return {};
+				}
+			},
+			...(Object.fromEntries(
+				(["top", "right", "bottom", "left"] as const).flatMap((dir) => {
+					const capDir = capitalize(dir);
+					// For table / table-cell elements, borders are applied via the `borders`
+					// key (consumed by TableCell / Table). Emitting `border` as well would
+					// create a visible Paragraph border on every child paragraph inside the
+					// cell, producing an unwanted 3-sided inner-cell box in Word.
+					const isCellLike = (el: DocumentElement) =>
+						el.type === "table-cell" || el.type === "table";
+					return [
+						[
+							`border${capDir}Color` satisfies StyleKey,
+							(v: string, el: DocumentElement) => ({
+								borders: { [dir]: { color: colorConversion(v) } },
+								...(isCellLike(el)
+									? {}
+									: { border: { [dir]: { color: colorConversion(v) } } }),
+							}),
+						],
+						[
+							`border${capDir}Style` satisfies StyleKey,
+							(v: string, el: DocumentElement) => {
+								const style = mapBorderStyle(v);
+								const size = style === BorderStyle.NONE ? { size: 0 } : {};
+								return {
+									borders: { [dir]: { style, ...size } },
+									...(isCellLike(el)
+										? {}
+										: { border: { [dir]: { style, ...size } } }),
+								};
+							},
+						],
+						[
+							`border${capDir}Width` satisfies StyleKey,
+							(v: string, el: DocumentElement) => {
+								const size = lengthToBorderSize(v);
+								return size === undefined
+									? {}
+									: {
+											borders: { [dir]: { size } },
+											...(isCellLike(el)
+												? {}
+												: { border: { [dir]: { size } } }),
+										};
+							},
+						],
+					];
+				}),
+			) satisfies DocxStyleMapping),
 
-      padding: (v, el) => {
-        if (el.type === 'table') return {};
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const twips = lengthToTwips(token);
-        if (typeof twips !== 'number') return {};
+			padding: (v, el) => {
+				if (el.type === "table") return {};
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const twips = lengthToTwips(token);
+				if (typeof twips !== "number") return {};
 
-        if (el.type === 'table-cell') {
-          return {
-            margins: { top: twips, bottom: twips, left: twips, right: twips },
-          };
-        }
+				if (el.type === "table-cell") {
+					return {
+						margins: { top: twips, bottom: twips, left: twips, right: twips },
+					};
+				}
 
-        // treat padding on paragraphs as extra spacing + indentation
-        return {
-          spacing: {
-            before: twips,
-            after: twips,
-          },
-          indent: {
-            left: twips,
-            right: twips,
-          },
-        };
-      },
-      margin: (v: string, el: DocumentElement) => {
-        const raw = v.trim();
-        const token = raw.split(/\s+/)[0] ?? '';
-        const twips = lengthToTwips(token);
-        if (typeof twips !== 'number') return {};
-        // Only apply wrap margins if image is floated
-        const floatDir = (el.styles as Styles & { float?: string })?.float;
-        if (
-          el.type === 'image' &&
-          (floatDir === 'left' || floatDir === 'right')
-        ) {
-          return {
-            floating: {
-              wrap: {
-                margins: {
-                  distL: twips,
-                  distR: twips,
-                  distT: twips,
-                  distB: twips,
-                },
-              },
-            },
-          };
-        }
-        // Tables: ignore
-        if (el.type === 'table') return {};
-        // Table cells: direct cell margins
-        if (el.type === 'table-cell') {
-          return {
-            margins: { top: twips, bottom: twips, left: twips, right: twips },
-          };
-        }
-        // Paragraphs: spacing + indent
-        const before = twips;
-        const after = twips;
-        const horiz = twips;
-        return {
-          spacing: { before, after },
-          indent: { left: horiz, right: horiz },
-        };
-      },
-      marginTop: (v: string, el: DocumentElement) => {
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const twips = lengthToTwips(token);
-        if (typeof twips !== 'number') return {};
-        // Only apply top wrap margin if image is floated
-        const floatDir = (el.styles as Styles & { float?: string })?.float;
-        if (
-          el.type === 'image' &&
-          (floatDir === 'left' || floatDir === 'right')
-        ) {
-          return { floating: { wrap: { margins: { distT: twips } } } };
-        }
-        if (el.type === 'table') return {};
-        if (el.type === 'table-cell') {
-          return { margins: { top: twips } };
-        }
-        return { spacing: { before: twips } };
-      },
+				// treat padding on paragraphs as extra spacing + indentation
+				return {
+					spacing: {
+						before: twips,
+						after: twips,
+					},
+					indent: {
+						left: twips,
+						right: twips,
+					},
+				};
+			},
+			margin: (v: string, el: DocumentElement) => {
+				const raw = v.trim();
+				const token = raw.split(/\s+/)[0] ?? "";
+				const twips = lengthToTwips(token);
+				if (typeof twips !== "number") return {};
+				// Only apply wrap margins if image is floated
+				const floatDir = (el.styles as Styles & { float?: string })?.float;
+				if (
+					el.type === "image" &&
+					(floatDir === "left" || floatDir === "right")
+				) {
+					return {
+						floating: {
+							wrap: {
+								margins: {
+									distL: twips,
+									distR: twips,
+									distT: twips,
+									distB: twips,
+								},
+							},
+						},
+					};
+				}
+				// Tables: ignore
+				if (el.type === "table") return {};
+				// Table cells: direct cell margins
+				if (el.type === "table-cell") {
+					return {
+						margins: { top: twips, bottom: twips, left: twips, right: twips },
+					};
+				}
+				// Paragraphs: spacing + indent
+				const before = twips;
+				const after = twips;
+				const horiz = twips;
+				return {
+					spacing: { before, after },
+					indent: { left: horiz, right: horiz },
+				};
+			},
+			marginTop: (v: string, el: DocumentElement) => {
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const twips = lengthToTwips(token);
+				if (typeof twips !== "number") return {};
+				// Only apply top wrap margin if image is floated
+				const floatDir = (el.styles as Styles & { float?: string })?.float;
+				if (
+					el.type === "image" &&
+					(floatDir === "left" || floatDir === "right")
+				) {
+					return { floating: { wrap: { margins: { distT: twips } } } };
+				}
+				if (el.type === "table") return {};
+				if (el.type === "table-cell") {
+					return { margins: { top: twips } };
+				}
+				return { spacing: { before: twips } };
+			},
 
-      marginBottom: (v: string, el: DocumentElement) => {
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const twips = lengthToTwips(token);
-        if (typeof twips !== 'number') return {};
-        // Only apply bottom wrap margin if image is floated
-        const floatDir = (el.styles as Styles & { float?: string })?.float;
-        if (
-          el.type === 'image' &&
-          (floatDir === 'left' || floatDir === 'right')
-        ) {
-          return { floating: { wrap: { margins: { distB: twips } } } };
-        }
-        if (el.type === 'table') return {};
-        if (el.type === 'table-cell') {
-          return { margins: { bottom: twips } };
-        }
-        return { spacing: { after: twips } };
-      },
+			marginBottom: (v: string, el: DocumentElement) => {
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const twips = lengthToTwips(token);
+				if (typeof twips !== "number") return {};
+				// Only apply bottom wrap margin if image is floated
+				const floatDir = (el.styles as Styles & { float?: string })?.float;
+				if (
+					el.type === "image" &&
+					(floatDir === "left" || floatDir === "right")
+				) {
+					return { floating: { wrap: { margins: { distB: twips } } } };
+				}
+				if (el.type === "table") return {};
+				if (el.type === "table-cell") {
+					return { margins: { bottom: twips } };
+				}
+				return { spacing: { after: twips } };
+			},
 
-      marginLeft: (v: string, el: DocumentElement) => {
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const twips = lengthToTwips(token);
-        if (typeof twips !== 'number') return {};
-        // Only apply left wrap margin if image is floated
-        const floatDir = (el.styles as Styles & { float?: string })?.float;
-        if (
-          el.type === 'image' &&
-          (floatDir === 'left' || floatDir === 'right')
-        ) {
-          return { floating: { wrap: { margins: { distL: twips } } } };
-        }
-        if (el.type === 'table') return {};
-        if (el.type === 'table-cell') {
-          return { margins: { left: twips } };
-        }
-        return { indent: { left: twips } };
-      },
-      paddingLeft: (v: string, el: DocumentElement) => {
-        if (el.type === 'table') return {};
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const space = lengthToTwips(token);
-        if (typeof space !== 'number') return {};
-        if (el.type === 'table-cell') {
-          return {
-            margins: {
-              left: space,
-            },
-          };
-        }
-        return {
-          border: {
-            left: { space },
-          },
-        };
-      },
-      paddingRight: (v: string, el: DocumentElement) => {
-        if (el.type === 'table') return {};
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const space = lengthToTwips(token);
-        if (typeof space !== 'number') return {};
-        if (el.type === 'table-cell') {
-          return {
-            margins: {
-              right: space,
-            },
-          };
-        }
-        return {
-          border: {
-            right: { space },
-          },
-        };
-      },
-      paddingTop: (v: string, el: DocumentElement) => {
-        if (el.type === 'table') return {};
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const space = lengthToTwips(token);
-        if (typeof space !== 'number') return {};
-        if (el.type === 'table-cell') {
-          return {
-            margins: {
-              top: space,
-            },
-          };
-        }
-        return {
-          border: {
-            top: { space },
-          },
-        };
-      },
-      paddingBottom: (v: string, el: DocumentElement) => {
-        if (el.type === 'table') return {};
-        const token = v.trim().split(/\s+/)[0] ?? '';
-        const space = lengthToTwips(token);
-        if (typeof space !== 'number') return {};
-        if (el.type === 'table-cell') {
-          return {
-            margins: {
-              bottom: space,
-            },
-          };
-        }
-        return {
-          border: {
-            bottom: { space },
-          },
-        };
-      },
-      listStyleType: (v) =>
-        v === 'decimal'
-          ? { numbering: 'decimal' }
-          : v === 'disc'
-            ? { bullet: true }
-            : {},
-    };
-  }
+			marginLeft: (v: string, el: DocumentElement) => {
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const twips = lengthToTwips(token);
+				if (typeof twips !== "number") return {};
+				// Only apply left wrap margin if image is floated
+				const floatDir = (el.styles as Styles & { float?: string })?.float;
+				if (
+					el.type === "image" &&
+					(floatDir === "left" || floatDir === "right")
+				) {
+					return { floating: { wrap: { margins: { distL: twips } } } };
+				}
+				if (el.type === "table") return {};
+				if (el.type === "table-cell") {
+					return { margins: { left: twips } };
+				}
+				return { indent: { left: twips } };
+			},
+			paddingLeft: (v: string, el: DocumentElement) => {
+				if (el.type === "table") return {};
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const space = lengthToTwips(token);
+				if (typeof space !== "number") return {};
+				if (el.type === "table-cell") {
+					return {
+						margins: {
+							left: space,
+						},
+					};
+				}
+				return {
+					border: {
+						left: { space },
+					},
+				};
+			},
+			paddingRight: (v: string, el: DocumentElement) => {
+				if (el.type === "table") return {};
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const space = lengthToTwips(token);
+				if (typeof space !== "number") return {};
+				if (el.type === "table-cell") {
+					return {
+						margins: {
+							right: space,
+						},
+					};
+				}
+				return {
+					border: {
+						right: { space },
+					},
+				};
+			},
+			paddingTop: (v: string, el: DocumentElement) => {
+				if (el.type === "table") return {};
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const space = lengthToTwips(token);
+				if (typeof space !== "number") return {};
+				if (el.type === "table-cell") {
+					return {
+						margins: {
+							top: space,
+						},
+					};
+				}
+				return {
+					border: {
+						top: { space },
+					},
+				};
+			},
+			paddingBottom: (v: string, el: DocumentElement) => {
+				if (el.type === "table") return {};
+				const token = v.trim().split(/\s+/)[0] ?? "";
+				const space = lengthToTwips(token);
+				if (typeof space !== "number") return {};
+				if (el.type === "table-cell") {
+					return {
+						margins: {
+							bottom: space,
+						},
+					};
+				}
+				return {
+					border: {
+						bottom: { space },
+					},
+				};
+			},
+			listStyleType: (v) =>
+				v === "decimal"
+					? { numbering: "decimal" }
+					: v === "disc"
+						? { bullet: true }
+						: {},
+		};
+	}
 
-  private expandShorthands(
-    rawStyles: Partial<Record<StyleKey, string | number>>
-  ) {
-    const mappedStyles: Partial<Record<StyleKey, string | number>> = {
-      ...rawStyles,
-    };
+	private expandShorthands(
+		rawStyles: Partial<Record<StyleKey, string | number>>,
+	) {
+		const mappedStyles: Partial<Record<StyleKey, string | number>> = {
+			...rawStyles,
+		};
 
-    const directions = ['top', 'right', 'bottom', 'left'] as const;
-    const capitalizedDirections = directions.map((dir) => capitalize(dir));
+		const directions = ["top", "right", "bottom", "left"] as const;
+		const capitalizedDirections = directions.map((dir) => capitalize(dir));
 
-    const borderDirections = capitalizedDirections.map(
-      (dir) => `border${dir}` satisfies StyleKey
-    );
+		const borderDirections = capitalizedDirections.map(
+			(dir) => `border${dir}` satisfies StyleKey,
+		);
 
-    const borderShorthand = (
-      prop: string | number
-    ): { width?: string | number; style?: string; color?: string } => {
-      if (typeof prop === 'number') {
-        return {
-          width: prop,
-        };
-      }
-      // TODO: Make sure that the order is corect
-      const widthRegex =
-        /^(thin|medium|thick|(\d+(\.\d+)?(px|em|rem|pt|cm|mm|in|pc|ex|ch|vw|vh|vmin|vmax|%)))$/i;
-      let width: string | undefined;
-      let style: string | undefined;
-      let color: string | undefined;
-      const parts = prop.split(/\s+/).filter(Boolean);
-      for (const part of parts) {
-        if (!width && widthRegex.test(part)) {
-          width = part;
-        } else if (
-          !style &&
-          borderStyleValues.includes(
-            // as any is okay when using .includes
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            part as any
-          )
-        ) {
-          style = part;
-        } else if (!color) {
-          color = part;
-        }
-      }
-      return { width, style, color };
-    };
+		const borderShorthand = (
+			prop: string | number,
+		): { width?: string | number; style?: string; color?: string } => {
+			if (typeof prop === "number") {
+				return {
+					width: prop,
+				};
+			}
+			// TODO: Make sure that the order is corect
+			const widthRegex =
+				/^(thin|medium|thick|(\d+(\.\d+)?(px|em|rem|pt|cm|mm|in|pc|ex|ch|vw|vh|vmin|vmax|%)))$/i;
+			let width: string | undefined;
+			let style: string | undefined;
+			let color: string | undefined;
+			const parts = prop.split(/\s+/).filter(Boolean);
+			for (const part of parts) {
+				if (!width && widthRegex.test(part)) {
+					width = part;
+				} else if (
+					!style &&
+					borderStyleValues.includes(
+						// as any is okay when using .includes
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						part as any,
+					)
+				) {
+					style = part;
+				} else if (!color) {
+					color = part;
+				}
+			}
+			return { width, style, color };
+		};
 
-    // Expand 'border' shorthand into individual border properties if not already set
-    if (mappedStyles.border) {
-      const borderValue = mappedStyles.border;
-      const { width, style, color } = borderShorthand(borderValue);
-      mappedStyles['borderWidth'] ??= width;
-      mappedStyles['borderStyle'] ??= style;
-      mappedStyles['borderColor'] ??= color;
-    }
+		// Expand 'border' shorthand into individual border properties if not already set
+		if (mappedStyles.border) {
+			const borderValue = mappedStyles.border;
+			const { width, style, color } = borderShorthand(borderValue);
+			mappedStyles["borderWidth"] ??= width;
+			mappedStyles["borderStyle"] ??= style;
+			mappedStyles["borderColor"] ??= color;
+		}
 
-    // FIXME: currently if border specifies a color, but the direction doesn't, the direction does not override it, but it should set it to the default.
-    borderDirections.forEach((borderDir) => {
-      const style = mappedStyles[borderDir];
-      if (style === undefined) return;
-      const { width, style: borderStyleValue, color } = borderShorthand(style);
-      const widthProp = `${borderDir}Width` satisfies StyleKey;
-      const styleProp = `${borderDir}Style` satisfies StyleKey;
-      const colorProp = `${borderDir}Color` satisfies StyleKey;
-      mappedStyles[widthProp] ??= width;
-      mappedStyles[styleProp] ??= borderStyleValue;
-      mappedStyles[colorProp] ??= color;
-    });
+		// FIXME: currently if border specifies a color, but the direction doesn't, the direction does not override it, but it should set it to the default.
+		borderDirections.forEach((borderDir) => {
+			const style = mappedStyles[borderDir];
+			if (style === undefined) return;
+			const { width, style: borderStyleValue, color } = borderShorthand(style);
+			const widthProp = `${borderDir}Width` satisfies StyleKey;
+			const styleProp = `${borderDir}Style` satisfies StyleKey;
+			const colorProp = `${borderDir}Color` satisfies StyleKey;
+			mappedStyles[widthProp] ??= width;
+			mappedStyles[styleProp] ??= borderStyleValue;
+			mappedStyles[colorProp] ??= color;
+		});
 
-    if (mappedStyles.borderWidth) {
-      const widthValue = mappedStyles.borderWidth;
-      capitalizedDirections.forEach((dir) => {
-        const prop = `border${dir}Width` satisfies StyleKey;
-        mappedStyles[prop] ??= widthValue;
-      });
-    }
-    if (mappedStyles.borderStyle) {
-      const styleValue = mappedStyles.borderStyle;
-      capitalizedDirections.forEach((dir) => {
-        const prop = `border${dir}Style` satisfies StyleKey;
-        mappedStyles[prop] ??= styleValue;
-      });
-    }
-    if (mappedStyles.borderColor) {
-      const colorValue = mappedStyles.borderColor;
-      capitalizedDirections.forEach((dir) => {
-        const prop = `border${dir}Color` satisfies StyleKey;
-        mappedStyles[prop] ??= colorValue;
-      });
-    }
+		if (mappedStyles.borderWidth) {
+			const widthValue = mappedStyles.borderWidth;
+			capitalizedDirections.forEach((dir) => {
+				const prop = `border${dir}Width` satisfies StyleKey;
+				mappedStyles[prop] ??= widthValue;
+			});
+		}
+		if (mappedStyles.borderStyle) {
+			const styleValue = mappedStyles.borderStyle;
+			capitalizedDirections.forEach((dir) => {
+				const prop = `border${dir}Style` satisfies StyleKey;
+				mappedStyles[prop] ??= styleValue;
+			});
+		}
+		if (mappedStyles.borderColor) {
+			const colorValue = mappedStyles.borderColor;
+			capitalizedDirections.forEach((dir) => {
+				const prop = `border${dir}Color` satisfies StyleKey;
+				mappedStyles[prop] ??= colorValue;
+			});
+		}
 
-    return mappedStyles;
-  }
+		return mappedStyles;
+	}
 
-  // Method to map raw styles to a generic style object
-  public mapStyles(
-    rawStyles: Partial<Record<StyleKey, string | number>>,
-    el: DocumentElement
-  ): Record<string, unknown> {
-    const expandedStyles = this.expandShorthands(rawStyles);
-    return (Object.keys(expandedStyles) as StyleKey[]).reduce(
-      (acc, cssProp) => {
-        const mapper = this.mappings[cssProp];
-        if (mapper && typeof expandedStyles[cssProp] === 'string') {
-          const newStyle = mapper(expandedStyles[cssProp], el) as object;
-          // Deep merge the new style into the accumulator
-          return deepMerge(acc, newStyle);
-        }
-        return acc;
-      },
-      {}
-    );
-  }
+	// Method to map raw styles to a generic style object
+	public mapStyles(
+		rawStyles: Partial<Record<StyleKey, string | number>>,
+		el: DocumentElement,
+	): Record<string, unknown> {
+		const expandedStyles = this.expandShorthands(rawStyles);
+		return (Object.keys(expandedStyles) as StyleKey[]).reduce(
+			(acc, cssProp) => {
+				const mapper = this.mappings[cssProp];
+				if (mapper && typeof expandedStyles[cssProp] === "string") {
+					const newStyle = mapper(expandedStyles[cssProp], el) as object;
+					// Deep merge the new style into the accumulator
+					return deepMerge(acc, newStyle);
+				}
+				return acc;
+			},
+			{},
+		);
+	}
 
-  // Method to add or override a mapping
-  public addMapping(mappings: DocxStyleMapping): void {
-    Object.entries(mappings).forEach((entries) => {
-      this.mappings[entries[0] as StyleKey] = entries[1];
-    });
-  }
+	// Method to add or override a mapping
+	public addMapping(mappings: DocxStyleMapping): void {
+		Object.entries(mappings).forEach((entries) => {
+			this.mappings[entries[0] as StyleKey] = entries[1];
+		});
+	}
 }

--- a/packages/adapters/docx/src/docx-style-mapper.ts
+++ b/packages/adapters/docx/src/docx-style-mapper.ts
@@ -1,786 +1,786 @@
 import {
-	BorderStyle,
-	// Floating image positioning and wrapping enums
-	HorizontalPositionAlign,
-	HorizontalPositionRelativeFrom,
-	type IImageOptions,
-	type ISpacingProperties,
-	type ITableRowOptions,
-	ShadingType,
-	TextWrappingSide,
-	TextWrappingType,
-	VerticalPositionAlign,
-	VerticalPositionRelativeFrom,
-} from "docx";
+  BorderStyle,
+  // Floating image positioning and wrapping enums
+  HorizontalPositionAlign,
+  HorizontalPositionRelativeFrom,
+  type IImageOptions,
+  type ISpacingProperties,
+  type ITableRowOptions,
+  ShadingType,
+  TextWrappingSide,
+  TextWrappingType,
+  VerticalPositionAlign,
+  VerticalPositionRelativeFrom,
+} from 'docx';
 import {
-	colorConversion,
-	type DocumentElement,
-	parseImageSizePx,
-	type Styles,
-} from "html-to-document-core";
-import { lengthToTwips, parseWidth } from "./utils/parse";
+  colorConversion,
+  type DocumentElement,
+  parseImageSizePx,
+  type Styles,
+} from 'html-to-document-core';
+import { lengthToTwips, parseWidth } from './utils/parse';
 import {
-	twipsToEighthsOfPoint,
-	twipsToEmus,
-	twipsToHalfPoints,
-} from "./utils/unit-conversion";
+  twipsToEighthsOfPoint,
+  twipsToEmus,
+  twipsToHalfPoints,
+} from './utils/unit-conversion';
 
 type StyleKey = keyof Styles;
 
 export type DocxStyleMapping = Partial<
-	Record<StyleKey, (value: string, el: DocumentElement) => unknown>
+  Record<StyleKey, (value: string, el: DocumentElement) => unknown>
 >;
 
 type DeepPartial<T> = {
-	[P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
 const BASE_FONT_SIZE_PX = 16;
 
 const capitalize = <S extends string>(value: S): Capitalize<S> => {
-	// @ts-expect-error - The logic is correct, but TypeScript doesn't understand that the return type is Capitalize<S>
-	return value.charAt(0).toUpperCase() + value.slice(1);
+  // @ts-expect-error - The logic is correct, but TypeScript doesn't understand that the return type is Capitalize<S>
+  return value.charAt(0).toUpperCase() + value.slice(1);
 };
 
 const borderStyleValues = [
-	"none",
-	"hidden",
-	"dotted",
-	"dashed",
-	"solid",
-	"double",
-	"groove",
-	"ridge",
-	"inset",
-	"outset",
+  'none',
+  'hidden',
+  'dotted',
+  'dashed',
+  'solid',
+  'double',
+  'groove',
+  'ridge',
+  'inset',
+  'outset',
 ] as const;
 
 const mapBorderStyle = (style: string): string => {
-	switch (style.toLowerCase()) {
-		case "none":
-		case "hidden":
-			return BorderStyle.NONE;
-		case "solid":
-			return BorderStyle.SINGLE;
-		case "dashed":
-			return BorderStyle.DASHED;
-		case "dotted":
-			return BorderStyle.DOTTED;
-		case "double":
-			return BorderStyle.DOUBLE;
-		case "groove":
-		case "ridge":
-		case "inset":
-		case "outset":
-			return BorderStyle.SINGLE;
-		default:
-			return BorderStyle.NONE;
-	}
+  switch (style.toLowerCase()) {
+    case 'none':
+    case 'hidden':
+      return BorderStyle.NONE;
+    case 'solid':
+      return BorderStyle.SINGLE;
+    case 'dashed':
+      return BorderStyle.DASHED;
+    case 'dotted':
+      return BorderStyle.DOTTED;
+    case 'double':
+      return BorderStyle.DOUBLE;
+    case 'groove':
+    case 'ridge':
+    case 'inset':
+    case 'outset':
+      return BorderStyle.SINGLE;
+    default:
+      return BorderStyle.NONE;
+  }
 };
 
 const lengthToBorderSize = (value: string): number | undefined => {
-	const twips = lengthToTwips(value);
-	return typeof twips === "number" ? twipsToEighthsOfPoint(twips) : undefined;
+  const twips = lengthToTwips(value);
+  return typeof twips === 'number' ? twipsToEighthsOfPoint(twips) : undefined;
 };
 
 function deepMerge<T extends object, U extends object>(
-	target: T,
-	source: U,
+  target: T,
+  source: U
 ): T & U {
-	const result = { ...target } as T & U;
-	for (const key of Object.keys(source)) {
-		const sourceValue = (source as Record<string, unknown>)[key];
-		if (
-			sourceValue &&
-			typeof sourceValue === "object" &&
-			!Array.isArray(sourceValue)
-		) {
-			const targetValue = (target as Record<string, unknown>)[key];
-			(result as Record<string, unknown>)[key] = deepMerge(
-				targetValue &&
-					typeof targetValue === "object" &&
-					!Array.isArray(targetValue)
-					? (targetValue as Record<string, unknown>)
-					: {},
-				sourceValue as Record<string, unknown>,
-			);
-		} else {
-			(result as Record<string, unknown>)[key] = sourceValue;
-		}
-	}
-	return result;
+  const result = { ...target } as T & U;
+  for (const key of Object.keys(source)) {
+    const sourceValue = (source as Record<string, unknown>)[key];
+    if (
+      sourceValue &&
+      typeof sourceValue === 'object' &&
+      !Array.isArray(sourceValue)
+    ) {
+      const targetValue = (target as Record<string, unknown>)[key];
+      (result as Record<string, unknown>)[key] = deepMerge(
+        targetValue &&
+          typeof targetValue === 'object' &&
+          !Array.isArray(targetValue)
+          ? (targetValue as Record<string, unknown>)
+          : {},
+        sourceValue as Record<string, unknown>
+      );
+    } else {
+      (result as Record<string, unknown>)[key] = sourceValue;
+    }
+  }
+  return result;
 }
 
 const textAlignMap: Record<string, string> = {
-	start: "left", // CSS “start” → left in LTR
-	left: "left",
-	end: "right", // CSS “end” → right in LTR
-	right: "right",
-	center: "center",
-	justify: "both", // docx uses “JUSTIFIED”
-	justified: "both",
+  start: 'left', // CSS “start” → left in LTR
+  left: 'left',
+  end: 'right', // CSS “end” → right in LTR
+  right: 'right',
+  center: 'center',
+  justify: 'both', // docx uses “JUSTIFIED”
+  justified: 'both',
 };
 
 // @To-do: Consider making the conversion from px or any other size extensible
 export class DocxStyleMapper {
-	protected mappings: DocxStyleMapping = {};
+  protected mappings: DocxStyleMapping = {};
 
-	constructor() {
-		this.initializeDefaultMappings();
-	}
+  constructor() {
+    this.initializeDefaultMappings();
+  }
 
-	// Central place for all default mappings
-	protected initializeDefaultMappings(): void {
-		this.mappings = {
-			borderSpacing: (v: string, el: DocumentElement) => {
-				if (el.type === "table") {
-					// CSS border-spacing accepts one or two values (horizontal [vertical])
-					// const parts = v.trim().split(/\s+/);
-					const token = v.trim().split(/\s+/)[0] ?? "";
-					const twips = lengthToTwips(token);
-					if (typeof twips === "number") {
-						// docx only supports uniform spacing, so use the horizontal value
-						return {
-							cellSpacing: {
-								value: twips,
-								type: "dxa",
-							},
-						};
-					}
-				}
-				return {};
-			},
-			float: (v: string, el: DocumentElement) => {
-				const floatValue = v.trim().toLowerCase();
-				if (floatValue === "left" || floatValue === "right") {
-					if (el.type === "image") {
-						// produce a floating image spec for text wrapping
-						return {
-							floating: {
-								horizontalPosition: {
-									relative: HorizontalPositionRelativeFrom.MARGIN,
-									align:
-										floatValue === "left"
-											? HorizontalPositionAlign.LEFT
-											: HorizontalPositionAlign.RIGHT,
-								},
-								verticalPosition: {
-									relative: VerticalPositionRelativeFrom.PARAGRAPH,
-									align: VerticalPositionAlign.TOP,
-								},
-								wrap: {
-									type: TextWrappingType.SQUARE,
-									side:
-										floatValue === "left"
-											? TextWrappingSide.RIGHT
-											: TextWrappingSide.LEFT,
-								},
-							},
-						};
-					}
-					// fallback: paragraph alignment for non-images
-					return { align: floatValue };
-				}
-				return {};
-			},
-			// Text-related styles
-			fontFamily: (v: string) => {
-				if (!v) return {};
-				// Split by comma in case multiple fonts are provided, then remove quotes and trim whitespace.
-				const fonts = v
-					.split(",")
-					.map((font) => font.trim().replace(/['"]/g, ""));
-				// Return the first font as the primary font
-				return { font: fonts[0] };
-			},
-			fontWeight: (v) => {
-				return v === "bold" ? { bold: true } : {};
-			},
-			fontStyle: (v) => (v === "italic" ? { italics: true } : {}),
-			textDecoration: (v: string) => {
-				const decorations = v
-					.split(/\s+/)
-					.map((s) => s.trim().toLowerCase())
-					.filter(Boolean);
+  // Central place for all default mappings
+  protected initializeDefaultMappings(): void {
+    this.mappings = {
+      borderSpacing: (v: string, el: DocumentElement) => {
+        if (el.type === 'table') {
+          // CSS border-spacing accepts one or two values (horizontal [vertical])
+          // const parts = v.trim().split(/\s+/);
+          const token = v.trim().split(/\s+/)[0] ?? '';
+          const twips = lengthToTwips(token);
+          if (typeof twips === 'number') {
+            // docx only supports uniform spacing, so use the horizontal value
+            return {
+              cellSpacing: {
+                value: twips,
+                type: 'dxa',
+              },
+            };
+          }
+        }
+        return {};
+      },
+      float: (v: string, el: DocumentElement) => {
+        const floatValue = v.trim().toLowerCase();
+        if (floatValue === 'left' || floatValue === 'right') {
+          if (el.type === 'image') {
+            // produce a floating image spec for text wrapping
+            return {
+              floating: {
+                horizontalPosition: {
+                  relative: HorizontalPositionRelativeFrom.MARGIN,
+                  align:
+                    floatValue === 'left'
+                      ? HorizontalPositionAlign.LEFT
+                      : HorizontalPositionAlign.RIGHT,
+                },
+                verticalPosition: {
+                  relative: VerticalPositionRelativeFrom.PARAGRAPH,
+                  align: VerticalPositionAlign.TOP,
+                },
+                wrap: {
+                  type: TextWrappingType.SQUARE,
+                  side:
+                    floatValue === 'left'
+                      ? TextWrappingSide.RIGHT
+                      : TextWrappingSide.LEFT,
+                },
+              },
+            };
+          }
+          // fallback: paragraph alignment for non-images
+          return { align: floatValue };
+        }
+        return {};
+      },
+      // Text-related styles
+      fontFamily: (v: string) => {
+        if (!v) return {};
+        // Split by comma in case multiple fonts are provided, then remove quotes and trim whitespace.
+        const fonts = v
+          .split(',')
+          .map((font) => font.trim().replace(/['"]/g, ''));
+        // Return the first font as the primary font
+        return { font: fonts[0] };
+      },
+      fontWeight: (v) => {
+        return v === 'bold' ? { bold: true } : {};
+      },
+      fontStyle: (v) => (v === 'italic' ? { italics: true } : {}),
+      textDecoration: (v: string) => {
+        const decorations = v
+          .split(/\s+/)
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean);
 
-				const style: Record<string, unknown> = {};
-				if (decorations.includes("underline")) {
-					style.underline = {};
-				}
-				if (decorations.includes("line-through")) {
-					style.strike = true;
-				}
-				return style;
-			},
-			textTransform: (v) =>
-				v === "uppercase"
-					? { allCaps: true }
-					: v === "capitalize"
-						? { smallCaps: true }
-						: {},
-			textAlign: (v, el) => {
-				if (el.type === "table") return {};
-				const key = v.trim().toLowerCase();
-				const alignment = textAlignMap[key];
-				return alignment ? { alignment } : {};
-			},
-			color: (v) => ({ color: colorConversion(v) }),
-			backgroundColor: (v, el) => {
-				if (el.type === "table") return {};
-				// strip “#” and turn CSS names → hex
-				const fill = colorConversion(v);
-				return {
-					shading: {
-						type: ShadingType.CLEAR,
-						fill, // e.g. "F9F9F9"
-						color: "auto", // text color fallback
-					},
-				};
-			},
+        const style: Record<string, unknown> = {};
+        if (decorations.includes('underline')) {
+          style.underline = {};
+        }
+        if (decorations.includes('line-through')) {
+          style.strike = true;
+        }
+        return style;
+      },
+      textTransform: (v) =>
+        v === 'uppercase'
+          ? { allCaps: true }
+          : v === 'capitalize'
+            ? { smallCaps: true }
+            : {},
+      textAlign: (v, el) => {
+        if (el.type === 'table') return {};
+        const key = v.trim().toLowerCase();
+        const alignment = textAlignMap[key];
+        return alignment ? { alignment } : {};
+      },
+      color: (v) => ({ color: colorConversion(v) }),
+      backgroundColor: (v, el) => {
+        if (el.type === 'table') return {};
+        // strip “#” and turn CSS names → hex
+        const fill = colorConversion(v);
+        return {
+          shading: {
+            type: ShadingType.CLEAR,
+            fill, // e.g. "F9F9F9"
+            color: 'auto', // text color fallback
+          },
+        };
+      },
 
-			// Font size
-			fontSize: (v) => {
-				const twips = lengthToTwips(v, { basePx: BASE_FONT_SIZE_PX });
-				return typeof twips === "number"
-					? { size: twipsToHalfPoints(twips) }
-					: {};
-			},
+      // Font size
+      fontSize: (v) => {
+        const twips = lengthToTwips(v, { basePx: BASE_FONT_SIZE_PX });
+        return typeof twips === 'number'
+          ? { size: twipsToHalfPoints(twips) }
+          : {};
+      },
 
-			// Line height and spacing
-			lineHeight: (v, el) => {
-				const raw = v.trim().toLowerCase();
-				const match = raw.match(/^([+-]?\d*\.?\d+)([a-z%]*)$/);
-				if (!match) return {};
-				const num = Number(match[1]);
-				if (!Number.isFinite(num)) return {};
-				const unit = match[2] ?? "";
-				if (!unit) {
-					return {
-						spacing: {
-							line: Math.round(num * 240), // 1 = 240 twips, which is single line spacing
-							lineRule: "auto",
-						} satisfies ISpacingProperties,
-					};
-				}
-				// TODO: handle '%' unit which is relative to the font size of the original element
+      // Line height and spacing
+      lineHeight: (v, el) => {
+        const raw = v.trim().toLowerCase();
+        const match = raw.match(/^([+-]?\d*\.?\d+)([a-z%]*)$/);
+        if (!match) return {};
+        const num = Number(match[1]);
+        if (!Number.isFinite(num)) return {};
+        const unit = match[2] ?? '';
+        if (!unit) {
+          return {
+            spacing: {
+              line: Math.round(num * 240), // 1 = 240 twips, which is single line spacing
+              lineRule: 'auto',
+            } satisfies ISpacingProperties,
+          };
+        }
+        // TODO: handle '%' unit which is relative to the font size of the original element
 
-				// TODO: get the font size in a better way
-				const fontSizeTwips =
-					lengthToTwips(el.styles?.fontSize ?? `${BASE_FONT_SIZE_PX}px`, {
-						basePx: BASE_FONT_SIZE_PX,
-					}) ?? Math.round(BASE_FONT_SIZE_PX * 15);
-				const basePx = fontSizeTwips / 15;
-				const lineTwips = lengthToTwips(raw, { basePx, unitless: "none" });
-				if (typeof lineTwips !== "number") return {};
+        // TODO: get the font size in a better way
+        const fontSizeTwips =
+          lengthToTwips(el.styles?.fontSize ?? `${BASE_FONT_SIZE_PX}px`, {
+            basePx: BASE_FONT_SIZE_PX,
+          }) ?? Math.round(BASE_FONT_SIZE_PX * 15);
+        const basePx = fontSizeTwips / 15;
+        const lineTwips = lengthToTwips(raw, { basePx, unitless: 'none' });
+        if (typeof lineTwips !== 'number') return {};
 
-				return {
-					spacing: {
-						line: lineTwips,
-						lineRule: "exact",
-					} satisfies ISpacingProperties,
-				};
-			},
-			width: (v, el) => {
-				// For images, map CSS width → ImageRun transformation width
-				if (el.type === "image") {
-					const px = parseImageSizePx(v);
-					return typeof px === "number"
-						? { transformation: { width: Math.round(px) } }
-						: {};
-				}
+        return {
+          spacing: {
+            line: lineTwips,
+            lineRule: 'exact',
+          } satisfies ISpacingProperties,
+        };
+      },
+      width: (v, el) => {
+        // For images, map CSS width → ImageRun transformation width
+        if (el.type === 'image') {
+          const px = parseImageSizePx(v);
+          return typeof px === 'number'
+            ? { transformation: { width: Math.round(px) } }
+            : {};
+        }
 
-				// All other elements keep using table/paragraph width logic
-				const parsed = parseWidth(v);
-				return parsed ? { width: parsed } : {};
-			},
-			height: (v, el) => {
-				// For images, map CSS height → ImageRun transformation height
-				if (el.type === "image") {
-					const px = parseImageSizePx(v);
-					return typeof px === "number"
-						? ({
-								transformation: { height: Math.round(px) },
-							} satisfies DeepPartial<IImageOptions>)
-						: {};
-				}
-				if (el.type === "table-row") {
-					const rowHeight = lengthToTwips(v);
-					if (typeof rowHeight !== "number") return {};
-					return {
-						height: {
-							rule: "exact",
-							value: rowHeight,
-						},
-					} satisfies DeepPartial<ITableRowOptions>;
-				}
-				const parsed = parseWidth(v);
-				return parsed ? { height: parsed } : {};
-			},
-			minHeight: (v, el) => {
-				if (el.type === "table-row") {
-					const rowHeight = lengthToTwips(v);
-					if (typeof rowHeight !== "number") return {};
-					return {
-						height: {
-							rule: "atLeast",
-							value: rowHeight,
-						},
-					} satisfies DeepPartial<ITableRowOptions>;
-				}
-				return {};
-			},
+        // All other elements keep using table/paragraph width logic
+        const parsed = parseWidth(v);
+        return parsed ? { width: parsed } : {};
+      },
+      height: (v, el) => {
+        // For images, map CSS height → ImageRun transformation height
+        if (el.type === 'image') {
+          const px = parseImageSizePx(v);
+          return typeof px === 'number'
+            ? ({
+                transformation: { height: Math.round(px) },
+              } satisfies DeepPartial<IImageOptions>)
+            : {};
+        }
+        if (el.type === 'table-row') {
+          const rowHeight = lengthToTwips(v);
+          if (typeof rowHeight !== 'number') return {};
+          return {
+            height: {
+              rule: 'exact',
+              value: rowHeight,
+            },
+          } satisfies DeepPartial<ITableRowOptions>;
+        }
+        const parsed = parseWidth(v);
+        return parsed ? { height: parsed } : {};
+      },
+      minHeight: (v, el) => {
+        if (el.type === 'table-row') {
+          const rowHeight = lengthToTwips(v);
+          if (typeof rowHeight !== 'number') return {};
+          return {
+            height: {
+              rule: 'atLeast',
+              value: rowHeight,
+            },
+          } satisfies DeepPartial<ITableRowOptions>;
+        }
+        return {};
+      },
 
-			letterSpacing: (v) => {
-				const twips = lengthToTwips(v);
-				return typeof twips === "number" ? { characterSpacing: twips } : {};
-			},
-			border: (v: string, el) => {
-				const raw = v.trim();
-				// For images, map CSS border shorthand to an outline around the picture
-				if (el.type === "image") {
-					// expect format: "<width> <style> <color>" (e.g. "2px dashed #333")
-					const parts = raw.split(/\s+/);
-					const widthPart = parts[0] || "";
-					const width = lengthToTwips(widthPart);
-					if (typeof width === "number" && parts.length >= 2) {
-						// parse color as last part
-						const colorPart = parts.slice(2).join(" ") || (parts[1] ?? "");
-						const color = colorConversion(colorPart);
-						return {
-							outline: {
-								width: twipsToEmus(width),
-								// solid fill stroke of outline
-								type: "solidFill",
-								solidFillType: "rgb",
-								value: color,
-							},
-						};
-					}
-					return {};
-				}
-				return {};
-			},
-			borderWidth: (v, el) => {
-				const size = lengthToBorderSize(v);
-				return size === undefined
-					? {}
-					: el.type === "table"
-						? {
-								borders: {
-									top: {
-										style: BorderStyle.SINGLE,
-										size,
-									},
-									bottom: {
-										style: BorderStyle.SINGLE,
-										size,
-									},
-									left: {
-										style: BorderStyle.SINGLE,
-										size,
-									},
-									right: {
-										style: BorderStyle.SINGLE,
-										size,
-									},
-								},
-							}
-						: {
-								border: {
-									top: { size },
-									bottom: { size },
-									left: { size },
-									right: { size },
-								},
-							};
-			},
-			verticalAlign: (v) => {
-				switch (v) {
-					case "top":
-						return { verticalAlign: "top" };
-					case "middle":
-						return { verticalAlign: "center" };
-					case "bottom":
-						return { verticalAlign: "bottom" };
-					case "super":
-						return { superScript: true };
-					case "sub":
-						return { subScript: true };
-					default:
-						return {};
-				}
-			},
-			...(Object.fromEntries(
-				(["top", "right", "bottom", "left"] as const).flatMap((dir) => {
-					const capDir = capitalize(dir);
-					// For table / table-cell elements, borders are applied via the `borders`
-					// key (consumed by TableCell / Table). Emitting `border` as well would
-					// create a visible Paragraph border on every child paragraph inside the
-					// cell, producing an unwanted 3-sided inner-cell box in Word.
-					const isCellLike = (el: DocumentElement) =>
-						el.type === "table-cell" || el.type === "table";
-					return [
-						[
-							`border${capDir}Color` satisfies StyleKey,
-							(v: string, el: DocumentElement) => ({
-								borders: { [dir]: { color: colorConversion(v) } },
-								...(isCellLike(el)
-									? {}
-									: { border: { [dir]: { color: colorConversion(v) } } }),
-							}),
-						],
-						[
-							`border${capDir}Style` satisfies StyleKey,
-							(v: string, el: DocumentElement) => {
-								const style = mapBorderStyle(v);
-								const size = style === BorderStyle.NONE ? { size: 0 } : {};
-								return {
-									borders: { [dir]: { style, ...size } },
-									...(isCellLike(el)
-										? {}
-										: { border: { [dir]: { style, ...size } } }),
-								};
-							},
-						],
-						[
-							`border${capDir}Width` satisfies StyleKey,
-							(v: string, el: DocumentElement) => {
-								const size = lengthToBorderSize(v);
-								return size === undefined
-									? {}
-									: {
-											borders: { [dir]: { size } },
-											...(isCellLike(el)
-												? {}
-												: { border: { [dir]: { size } } }),
-										};
-							},
-						],
-					];
-				}),
-			) satisfies DocxStyleMapping),
+      letterSpacing: (v) => {
+        const twips = lengthToTwips(v);
+        return typeof twips === 'number' ? { characterSpacing: twips } : {};
+      },
+      border: (v: string, el) => {
+        const raw = v.trim();
+        // For images, map CSS border shorthand to an outline around the picture
+        if (el.type === 'image') {
+          // expect format: "<width> <style> <color>" (e.g. "2px dashed #333")
+          const parts = raw.split(/\s+/);
+          const widthPart = parts[0] || '';
+          const width = lengthToTwips(widthPart);
+          if (typeof width === 'number' && parts.length >= 2) {
+            // parse color as last part
+            const colorPart = parts.slice(2).join(' ') || (parts[1] ?? '');
+            const color = colorConversion(colorPart);
+            return {
+              outline: {
+                width: twipsToEmus(width),
+                // solid fill stroke of outline
+                type: 'solidFill',
+                solidFillType: 'rgb',
+                value: color,
+              },
+            };
+          }
+          return {};
+        }
+        return {};
+      },
+      borderWidth: (v, el) => {
+        const size = lengthToBorderSize(v);
+        return size === undefined
+          ? {}
+          : el.type === 'table'
+            ? {
+                borders: {
+                  top: {
+                    style: BorderStyle.SINGLE,
+                    size,
+                  },
+                  bottom: {
+                    style: BorderStyle.SINGLE,
+                    size,
+                  },
+                  left: {
+                    style: BorderStyle.SINGLE,
+                    size,
+                  },
+                  right: {
+                    style: BorderStyle.SINGLE,
+                    size,
+                  },
+                },
+              }
+            : {
+                border: {
+                  top: { size },
+                  bottom: { size },
+                  left: { size },
+                  right: { size },
+                },
+              };
+      },
+      verticalAlign: (v) => {
+        switch (v) {
+          case 'top':
+            return { verticalAlign: 'top' };
+          case 'middle':
+            return { verticalAlign: 'center' };
+          case 'bottom':
+            return { verticalAlign: 'bottom' };
+          case 'super':
+            return { superScript: true };
+          case 'sub':
+            return { subScript: true };
+          default:
+            return {};
+        }
+      },
+      ...(Object.fromEntries(
+        (['top', 'right', 'bottom', 'left'] as const).flatMap((dir) => {
+          const capDir = capitalize(dir);
+          // For table / table-cell elements, borders are applied via the `borders`
+          // key (consumed by TableCell / Table). Emitting `border` as well would
+          // create a visible Paragraph border on every child paragraph inside the
+          // cell, producing an unwanted 3-sided inner-cell box in Word.
+          const isCellLike = (el: DocumentElement) =>
+            el.type === 'table-cell' || el.type === 'table';
+          return [
+            [
+              `border${capDir}Color` satisfies StyleKey,
+              (v: string, el: DocumentElement) => ({
+                borders: { [dir]: { color: colorConversion(v) } },
+                ...(isCellLike(el)
+                  ? {}
+                  : { border: { [dir]: { color: colorConversion(v) } } }),
+              }),
+            ],
+            [
+              `border${capDir}Style` satisfies StyleKey,
+              (v: string, el: DocumentElement) => {
+                const style = mapBorderStyle(v);
+                const size = style === BorderStyle.NONE ? { size: 0 } : {};
+                return {
+                  borders: { [dir]: { style, ...size } },
+                  ...(isCellLike(el)
+                    ? {}
+                    : { border: { [dir]: { style, ...size } } }),
+                };
+              },
+            ],
+            [
+              `border${capDir}Width` satisfies StyleKey,
+              (v: string, el: DocumentElement) => {
+                const size = lengthToBorderSize(v);
+                return size === undefined
+                  ? {}
+                  : {
+                      borders: { [dir]: { size } },
+                      ...(isCellLike(el)
+                        ? {}
+                        : { border: { [dir]: { size } } }),
+                    };
+              },
+            ],
+          ];
+        })
+      ) satisfies DocxStyleMapping),
 
-			padding: (v, el) => {
-				if (el.type === "table") return {};
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const twips = lengthToTwips(token);
-				if (typeof twips !== "number") return {};
+      padding: (v, el) => {
+        if (el.type === 'table') return {};
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const twips = lengthToTwips(token);
+        if (typeof twips !== 'number') return {};
 
-				if (el.type === "table-cell") {
-					return {
-						margins: { top: twips, bottom: twips, left: twips, right: twips },
-					};
-				}
+        if (el.type === 'table-cell') {
+          return {
+            margins: { top: twips, bottom: twips, left: twips, right: twips },
+          };
+        }
 
-				// treat padding on paragraphs as extra spacing + indentation
-				return {
-					spacing: {
-						before: twips,
-						after: twips,
-					},
-					indent: {
-						left: twips,
-						right: twips,
-					},
-				};
-			},
-			margin: (v: string, el: DocumentElement) => {
-				const raw = v.trim();
-				const token = raw.split(/\s+/)[0] ?? "";
-				const twips = lengthToTwips(token);
-				if (typeof twips !== "number") return {};
-				// Only apply wrap margins if image is floated
-				const floatDir = (el.styles as Styles & { float?: string })?.float;
-				if (
-					el.type === "image" &&
-					(floatDir === "left" || floatDir === "right")
-				) {
-					return {
-						floating: {
-							wrap: {
-								margins: {
-									distL: twips,
-									distR: twips,
-									distT: twips,
-									distB: twips,
-								},
-							},
-						},
-					};
-				}
-				// Tables: ignore
-				if (el.type === "table") return {};
-				// Table cells: direct cell margins
-				if (el.type === "table-cell") {
-					return {
-						margins: { top: twips, bottom: twips, left: twips, right: twips },
-					};
-				}
-				// Paragraphs: spacing + indent
-				const before = twips;
-				const after = twips;
-				const horiz = twips;
-				return {
-					spacing: { before, after },
-					indent: { left: horiz, right: horiz },
-				};
-			},
-			marginTop: (v: string, el: DocumentElement) => {
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const twips = lengthToTwips(token);
-				if (typeof twips !== "number") return {};
-				// Only apply top wrap margin if image is floated
-				const floatDir = (el.styles as Styles & { float?: string })?.float;
-				if (
-					el.type === "image" &&
-					(floatDir === "left" || floatDir === "right")
-				) {
-					return { floating: { wrap: { margins: { distT: twips } } } };
-				}
-				if (el.type === "table") return {};
-				if (el.type === "table-cell") {
-					return { margins: { top: twips } };
-				}
-				return { spacing: { before: twips } };
-			},
+        // treat padding on paragraphs as extra spacing + indentation
+        return {
+          spacing: {
+            before: twips,
+            after: twips,
+          },
+          indent: {
+            left: twips,
+            right: twips,
+          },
+        };
+      },
+      margin: (v: string, el: DocumentElement) => {
+        const raw = v.trim();
+        const token = raw.split(/\s+/)[0] ?? '';
+        const twips = lengthToTwips(token);
+        if (typeof twips !== 'number') return {};
+        // Only apply wrap margins if image is floated
+        const floatDir = (el.styles as Styles & { float?: string })?.float;
+        if (
+          el.type === 'image' &&
+          (floatDir === 'left' || floatDir === 'right')
+        ) {
+          return {
+            floating: {
+              wrap: {
+                margins: {
+                  distL: twips,
+                  distR: twips,
+                  distT: twips,
+                  distB: twips,
+                },
+              },
+            },
+          };
+        }
+        // Tables: ignore
+        if (el.type === 'table') return {};
+        // Table cells: direct cell margins
+        if (el.type === 'table-cell') {
+          return {
+            margins: { top: twips, bottom: twips, left: twips, right: twips },
+          };
+        }
+        // Paragraphs: spacing + indent
+        const before = twips;
+        const after = twips;
+        const horiz = twips;
+        return {
+          spacing: { before, after },
+          indent: { left: horiz, right: horiz },
+        };
+      },
+      marginTop: (v: string, el: DocumentElement) => {
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const twips = lengthToTwips(token);
+        if (typeof twips !== 'number') return {};
+        // Only apply top wrap margin if image is floated
+        const floatDir = (el.styles as Styles & { float?: string })?.float;
+        if (
+          el.type === 'image' &&
+          (floatDir === 'left' || floatDir === 'right')
+        ) {
+          return { floating: { wrap: { margins: { distT: twips } } } };
+        }
+        if (el.type === 'table') return {};
+        if (el.type === 'table-cell') {
+          return { margins: { top: twips } };
+        }
+        return { spacing: { before: twips } };
+      },
 
-			marginBottom: (v: string, el: DocumentElement) => {
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const twips = lengthToTwips(token);
-				if (typeof twips !== "number") return {};
-				// Only apply bottom wrap margin if image is floated
-				const floatDir = (el.styles as Styles & { float?: string })?.float;
-				if (
-					el.type === "image" &&
-					(floatDir === "left" || floatDir === "right")
-				) {
-					return { floating: { wrap: { margins: { distB: twips } } } };
-				}
-				if (el.type === "table") return {};
-				if (el.type === "table-cell") {
-					return { margins: { bottom: twips } };
-				}
-				return { spacing: { after: twips } };
-			},
+      marginBottom: (v: string, el: DocumentElement) => {
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const twips = lengthToTwips(token);
+        if (typeof twips !== 'number') return {};
+        // Only apply bottom wrap margin if image is floated
+        const floatDir = (el.styles as Styles & { float?: string })?.float;
+        if (
+          el.type === 'image' &&
+          (floatDir === 'left' || floatDir === 'right')
+        ) {
+          return { floating: { wrap: { margins: { distB: twips } } } };
+        }
+        if (el.type === 'table') return {};
+        if (el.type === 'table-cell') {
+          return { margins: { bottom: twips } };
+        }
+        return { spacing: { after: twips } };
+      },
 
-			marginLeft: (v: string, el: DocumentElement) => {
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const twips = lengthToTwips(token);
-				if (typeof twips !== "number") return {};
-				// Only apply left wrap margin if image is floated
-				const floatDir = (el.styles as Styles & { float?: string })?.float;
-				if (
-					el.type === "image" &&
-					(floatDir === "left" || floatDir === "right")
-				) {
-					return { floating: { wrap: { margins: { distL: twips } } } };
-				}
-				if (el.type === "table") return {};
-				if (el.type === "table-cell") {
-					return { margins: { left: twips } };
-				}
-				return { indent: { left: twips } };
-			},
-			paddingLeft: (v: string, el: DocumentElement) => {
-				if (el.type === "table") return {};
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const space = lengthToTwips(token);
-				if (typeof space !== "number") return {};
-				if (el.type === "table-cell") {
-					return {
-						margins: {
-							left: space,
-						},
-					};
-				}
-				return {
-					border: {
-						left: { space },
-					},
-				};
-			},
-			paddingRight: (v: string, el: DocumentElement) => {
-				if (el.type === "table") return {};
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const space = lengthToTwips(token);
-				if (typeof space !== "number") return {};
-				if (el.type === "table-cell") {
-					return {
-						margins: {
-							right: space,
-						},
-					};
-				}
-				return {
-					border: {
-						right: { space },
-					},
-				};
-			},
-			paddingTop: (v: string, el: DocumentElement) => {
-				if (el.type === "table") return {};
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const space = lengthToTwips(token);
-				if (typeof space !== "number") return {};
-				if (el.type === "table-cell") {
-					return {
-						margins: {
-							top: space,
-						},
-					};
-				}
-				return {
-					border: {
-						top: { space },
-					},
-				};
-			},
-			paddingBottom: (v: string, el: DocumentElement) => {
-				if (el.type === "table") return {};
-				const token = v.trim().split(/\s+/)[0] ?? "";
-				const space = lengthToTwips(token);
-				if (typeof space !== "number") return {};
-				if (el.type === "table-cell") {
-					return {
-						margins: {
-							bottom: space,
-						},
-					};
-				}
-				return {
-					border: {
-						bottom: { space },
-					},
-				};
-			},
-			listStyleType: (v) =>
-				v === "decimal"
-					? { numbering: "decimal" }
-					: v === "disc"
-						? { bullet: true }
-						: {},
-		};
-	}
+      marginLeft: (v: string, el: DocumentElement) => {
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const twips = lengthToTwips(token);
+        if (typeof twips !== 'number') return {};
+        // Only apply left wrap margin if image is floated
+        const floatDir = (el.styles as Styles & { float?: string })?.float;
+        if (
+          el.type === 'image' &&
+          (floatDir === 'left' || floatDir === 'right')
+        ) {
+          return { floating: { wrap: { margins: { distL: twips } } } };
+        }
+        if (el.type === 'table') return {};
+        if (el.type === 'table-cell') {
+          return { margins: { left: twips } };
+        }
+        return { indent: { left: twips } };
+      },
+      paddingLeft: (v: string, el: DocumentElement) => {
+        if (el.type === 'table') return {};
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const space = lengthToTwips(token);
+        if (typeof space !== 'number') return {};
+        if (el.type === 'table-cell') {
+          return {
+            margins: {
+              left: space,
+            },
+          };
+        }
+        return {
+          border: {
+            left: { space },
+          },
+        };
+      },
+      paddingRight: (v: string, el: DocumentElement) => {
+        if (el.type === 'table') return {};
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const space = lengthToTwips(token);
+        if (typeof space !== 'number') return {};
+        if (el.type === 'table-cell') {
+          return {
+            margins: {
+              right: space,
+            },
+          };
+        }
+        return {
+          border: {
+            right: { space },
+          },
+        };
+      },
+      paddingTop: (v: string, el: DocumentElement) => {
+        if (el.type === 'table') return {};
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const space = lengthToTwips(token);
+        if (typeof space !== 'number') return {};
+        if (el.type === 'table-cell') {
+          return {
+            margins: {
+              top: space,
+            },
+          };
+        }
+        return {
+          border: {
+            top: { space },
+          },
+        };
+      },
+      paddingBottom: (v: string, el: DocumentElement) => {
+        if (el.type === 'table') return {};
+        const token = v.trim().split(/\s+/)[0] ?? '';
+        const space = lengthToTwips(token);
+        if (typeof space !== 'number') return {};
+        if (el.type === 'table-cell') {
+          return {
+            margins: {
+              bottom: space,
+            },
+          };
+        }
+        return {
+          border: {
+            bottom: { space },
+          },
+        };
+      },
+      listStyleType: (v) =>
+        v === 'decimal'
+          ? { numbering: 'decimal' }
+          : v === 'disc'
+            ? { bullet: true }
+            : {},
+    };
+  }
 
-	private expandShorthands(
-		rawStyles: Partial<Record<StyleKey, string | number>>,
-	) {
-		const mappedStyles: Partial<Record<StyleKey, string | number>> = {
-			...rawStyles,
-		};
+  private expandShorthands(
+    rawStyles: Partial<Record<StyleKey, string | number>>
+  ) {
+    const mappedStyles: Partial<Record<StyleKey, string | number>> = {
+      ...rawStyles,
+    };
 
-		const directions = ["top", "right", "bottom", "left"] as const;
-		const capitalizedDirections = directions.map((dir) => capitalize(dir));
+    const directions = ['top', 'right', 'bottom', 'left'] as const;
+    const capitalizedDirections = directions.map((dir) => capitalize(dir));
 
-		const borderDirections = capitalizedDirections.map(
-			(dir) => `border${dir}` satisfies StyleKey,
-		);
+    const borderDirections = capitalizedDirections.map(
+      (dir) => `border${dir}` satisfies StyleKey
+    );
 
-		const borderShorthand = (
-			prop: string | number,
-		): { width?: string | number; style?: string; color?: string } => {
-			if (typeof prop === "number") {
-				return {
-					width: prop,
-				};
-			}
-			// TODO: Make sure that the order is corect
-			const widthRegex =
-				/^(thin|medium|thick|(\d+(\.\d+)?(px|em|rem|pt|cm|mm|in|pc|ex|ch|vw|vh|vmin|vmax|%)))$/i;
-			let width: string | undefined;
-			let style: string | undefined;
-			let color: string | undefined;
-			const parts = prop.split(/\s+/).filter(Boolean);
-			for (const part of parts) {
-				if (!width && widthRegex.test(part)) {
-					width = part;
-				} else if (
-					!style &&
-					borderStyleValues.includes(
-						// as any is okay when using .includes
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						part as any,
-					)
-				) {
-					style = part;
-				} else if (!color) {
-					color = part;
-				}
-			}
-			return { width, style, color };
-		};
+    const borderShorthand = (
+      prop: string | number
+    ): { width?: string | number; style?: string; color?: string } => {
+      if (typeof prop === 'number') {
+        return {
+          width: prop,
+        };
+      }
+      // TODO: Make sure that the order is corect
+      const widthRegex =
+        /^(thin|medium|thick|(\d+(\.\d+)?(px|em|rem|pt|cm|mm|in|pc|ex|ch|vw|vh|vmin|vmax|%)))$/i;
+      let width: string | undefined;
+      let style: string | undefined;
+      let color: string | undefined;
+      const parts = prop.split(/\s+/).filter(Boolean);
+      for (const part of parts) {
+        if (!width && widthRegex.test(part)) {
+          width = part;
+        } else if (
+          !style &&
+          borderStyleValues.includes(
+            // as any is okay when using .includes
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            part as any
+          )
+        ) {
+          style = part;
+        } else if (!color) {
+          color = part;
+        }
+      }
+      return { width, style, color };
+    };
 
-		// Expand 'border' shorthand into individual border properties if not already set
-		if (mappedStyles.border) {
-			const borderValue = mappedStyles.border;
-			const { width, style, color } = borderShorthand(borderValue);
-			mappedStyles["borderWidth"] ??= width;
-			mappedStyles["borderStyle"] ??= style;
-			mappedStyles["borderColor"] ??= color;
-		}
+    // Expand 'border' shorthand into individual border properties if not already set
+    if (mappedStyles.border) {
+      const borderValue = mappedStyles.border;
+      const { width, style, color } = borderShorthand(borderValue);
+      mappedStyles['borderWidth'] ??= width;
+      mappedStyles['borderStyle'] ??= style;
+      mappedStyles['borderColor'] ??= color;
+    }
 
-		// FIXME: currently if border specifies a color, but the direction doesn't, the direction does not override it, but it should set it to the default.
-		borderDirections.forEach((borderDir) => {
-			const style = mappedStyles[borderDir];
-			if (style === undefined) return;
-			const { width, style: borderStyleValue, color } = borderShorthand(style);
-			const widthProp = `${borderDir}Width` satisfies StyleKey;
-			const styleProp = `${borderDir}Style` satisfies StyleKey;
-			const colorProp = `${borderDir}Color` satisfies StyleKey;
-			mappedStyles[widthProp] ??= width;
-			mappedStyles[styleProp] ??= borderStyleValue;
-			mappedStyles[colorProp] ??= color;
-		});
+    // FIXME: currently if border specifies a color, but the direction doesn't, the direction does not override it, but it should set it to the default.
+    borderDirections.forEach((borderDir) => {
+      const style = mappedStyles[borderDir];
+      if (style === undefined) return;
+      const { width, style: borderStyleValue, color } = borderShorthand(style);
+      const widthProp = `${borderDir}Width` satisfies StyleKey;
+      const styleProp = `${borderDir}Style` satisfies StyleKey;
+      const colorProp = `${borderDir}Color` satisfies StyleKey;
+      mappedStyles[widthProp] ??= width;
+      mappedStyles[styleProp] ??= borderStyleValue;
+      mappedStyles[colorProp] ??= color;
+    });
 
-		if (mappedStyles.borderWidth) {
-			const widthValue = mappedStyles.borderWidth;
-			capitalizedDirections.forEach((dir) => {
-				const prop = `border${dir}Width` satisfies StyleKey;
-				mappedStyles[prop] ??= widthValue;
-			});
-		}
-		if (mappedStyles.borderStyle) {
-			const styleValue = mappedStyles.borderStyle;
-			capitalizedDirections.forEach((dir) => {
-				const prop = `border${dir}Style` satisfies StyleKey;
-				mappedStyles[prop] ??= styleValue;
-			});
-		}
-		if (mappedStyles.borderColor) {
-			const colorValue = mappedStyles.borderColor;
-			capitalizedDirections.forEach((dir) => {
-				const prop = `border${dir}Color` satisfies StyleKey;
-				mappedStyles[prop] ??= colorValue;
-			});
-		}
+    if (mappedStyles.borderWidth) {
+      const widthValue = mappedStyles.borderWidth;
+      capitalizedDirections.forEach((dir) => {
+        const prop = `border${dir}Width` satisfies StyleKey;
+        mappedStyles[prop] ??= widthValue;
+      });
+    }
+    if (mappedStyles.borderStyle) {
+      const styleValue = mappedStyles.borderStyle;
+      capitalizedDirections.forEach((dir) => {
+        const prop = `border${dir}Style` satisfies StyleKey;
+        mappedStyles[prop] ??= styleValue;
+      });
+    }
+    if (mappedStyles.borderColor) {
+      const colorValue = mappedStyles.borderColor;
+      capitalizedDirections.forEach((dir) => {
+        const prop = `border${dir}Color` satisfies StyleKey;
+        mappedStyles[prop] ??= colorValue;
+      });
+    }
 
-		return mappedStyles;
-	}
+    return mappedStyles;
+  }
 
-	// Method to map raw styles to a generic style object
-	public mapStyles(
-		rawStyles: Partial<Record<StyleKey, string | number>>,
-		el: DocumentElement,
-	): Record<string, unknown> {
-		const expandedStyles = this.expandShorthands(rawStyles);
-		return (Object.keys(expandedStyles) as StyleKey[]).reduce(
-			(acc, cssProp) => {
-				const mapper = this.mappings[cssProp];
-				if (mapper && typeof expandedStyles[cssProp] === "string") {
-					const newStyle = mapper(expandedStyles[cssProp], el) as object;
-					// Deep merge the new style into the accumulator
-					return deepMerge(acc, newStyle);
-				}
-				return acc;
-			},
-			{},
-		);
-	}
+  // Method to map raw styles to a generic style object
+  public mapStyles(
+    rawStyles: Partial<Record<StyleKey, string | number>>,
+    el: DocumentElement
+  ): Record<string, unknown> {
+    const expandedStyles = this.expandShorthands(rawStyles);
+    return (Object.keys(expandedStyles) as StyleKey[]).reduce(
+      (acc, cssProp) => {
+        const mapper = this.mappings[cssProp];
+        if (mapper && typeof expandedStyles[cssProp] === 'string') {
+          const newStyle = mapper(expandedStyles[cssProp], el) as object;
+          // Deep merge the new style into the accumulator
+          return deepMerge(acc, newStyle);
+        }
+        return acc;
+      },
+      {}
+    );
+  }
 
-	// Method to add or override a mapping
-	public addMapping(mappings: DocxStyleMapping): void {
-		Object.entries(mappings).forEach((entries) => {
-			this.mappings[entries[0] as StyleKey] = entries[1];
-		});
-	}
+  // Method to add or override a mapping
+  public addMapping(mappings: DocxStyleMapping): void {
+    Object.entries(mappings).forEach((entries) => {
+      this.mappings[entries[0] as StyleKey] = entries[1];
+    });
+  }
 }

--- a/packages/adapters/docx/src/docx-style-mapper.ts
+++ b/packages/adapters/docx/src/docx-style-mapper.ts
@@ -413,46 +413,34 @@ export class DocxStyleMapper {
       ...(Object.fromEntries(
         (['top', 'right', 'bottom', 'left'] as const).flatMap((dir) => {
           const capDir = capitalize(dir);
-          // For table / table-cell elements, borders are applied via the `borders`
-          // key (consumed by TableCell / Table). Emitting `border` as well would
-          // create a visible Paragraph border on every child paragraph inside the
-          // cell, producing an unwanted 3-sided inner-cell box in Word.
-          const isCellLike = (el: DocumentElement) =>
-            el.type === 'table-cell' || el.type === 'table';
           return [
             [
               `border${capDir}Color` satisfies StyleKey,
-              (v: string, el: DocumentElement) => ({
+              (v: string) => ({
                 borders: { [dir]: { color: colorConversion(v) } },
-                ...(isCellLike(el)
-                  ? {}
-                  : { border: { [dir]: { color: colorConversion(v) } } }),
+                border: { [dir]: { color: colorConversion(v) } },
               }),
             ],
             [
               `border${capDir}Style` satisfies StyleKey,
-              (v: string, el: DocumentElement) => {
+              (v: string) => {
                 const style = mapBorderStyle(v);
                 const size = style === BorderStyle.NONE ? { size: 0 } : {};
                 return {
                   borders: { [dir]: { style, ...size } },
-                  ...(isCellLike(el)
-                    ? {}
-                    : { border: { [dir]: { style, ...size } } }),
+                  border: { [dir]: { style, ...size } },
                 };
               },
             ],
             [
               `border${capDir}Width` satisfies StyleKey,
-              (v: string, el: DocumentElement) => {
+              (v: string) => {
                 const size = lengthToBorderSize(v);
                 return size === undefined
                   ? {}
                   : {
                       borders: { [dir]: { size } },
-                      ...(isCellLike(el)
-                        ? {}
-                        : { border: { [dir]: { size } } }),
+                      border: { [dir]: { size } },
                     };
               },
             ],

--- a/packages/adapters/docx/src/element-converters/block/list-item.ts
+++ b/packages/adapters/docx/src/element-converters/block/list-item.ts
@@ -1,4 +1,5 @@
 import {
+  cascadeStyles,
   DocumentElement,
   ListItemElement,
   Styles,
@@ -19,6 +20,7 @@ export class ListItemConverter implements IBlockConverter<DocumentElementType> {
       converter,
       defaultStyles,
       stylesheet,
+      styleMeta,
     }: ElementConverterDependencies,
     element: ListItemElement,
     cascadedStyles: Styles = {}
@@ -27,15 +29,20 @@ export class ListItemConverter implements IBlockConverter<DocumentElementType> {
       ...defaultStyles?.[element.type],
       ...stylesheet.getComputedStyles(element, cascadedStyles),
     };
+    const cascadingStyles = cascadeStyles(
+      mergedStyles,
+      element.scope,
+      styleMeta
+    );
 
     return converter.convertToBlocks({
       stylesheet,
-      cascadedStyles: mergedStyles,
+      cascadedStyles: cascadingStyles,
       inlineParagraphs: true,
       element,
       convertBlock: (dependencies, childBlock) => {
         const { converter: conv } = dependencies;
-        return conv.convertBlock(childBlock, stylesheet, mergedStyles);
+        return conv.convertBlock(childBlock, stylesheet, cascadingStyles);
       },
       wrapInlineElements: (inlines) => {
         const styles = styleMapper.mapStyles(mergedStyles, element);

--- a/packages/adapters/docx/src/element-converters/block/list.ts
+++ b/packages/adapters/docx/src/element-converters/block/list.ts
@@ -1,5 +1,6 @@
 import { FileChild } from 'docx';
 import {
+  cascadeStyles,
   DocumentElement,
   filterForScope,
   ListElement,
@@ -20,13 +21,18 @@ export class ListConverter implements IBlockConverter<DocumentElementType> {
     element: DocumentElementType,
     cascadedStyles: Styles = {}
   ): FileChild[] | Promise<FileChild[]> {
-    const { defaultStyles, stylesheet } = dependencies;
+    const { defaultStyles, stylesheet, styleMeta } = dependencies;
     const inherited = filterForScope(cascadedStyles, element.scope);
     // Paragraph element must only have inline children or else it could corrupt the document structure.
     const mergedStyles = {
       ...defaultStyles?.[element.type],
       ...stylesheet.getComputedStyles(element, inherited),
     };
+    const cascadingStyles = cascadeStyles(
+      mergedStyles,
+      element.scope,
+      styleMeta
+    );
 
     return promiseAllFlat(
       element.content.map((child) => {
@@ -37,7 +43,7 @@ export class ListConverter implements IBlockConverter<DocumentElementType> {
         return dependencies.converter.convertBlock(
           child,
           dependencies.stylesheet,
-          mergedStyles
+          cascadingStyles
         );
       })
     );

--- a/packages/adapters/docx/src/element-converters/block/paragraph.ts
+++ b/packages/adapters/docx/src/element-converters/block/paragraph.ts
@@ -39,7 +39,7 @@ export class ParagraphConverter implements IBlockConverter<ParagraphElement> {
       cascadedStyles: cascadingStyles,
       convertBlock: (dependencies, childBlock) => {
         const { converter } = dependencies;
-        return converter.convertBlock(childBlock, stylesheet, mergedStyles);
+        return converter.convertBlock(childBlock, stylesheet, cascadingStyles);
       },
       wrapInlineElements: (inlines) => {
         const children = inlines;

--- a/packages/adapters/docx/src/element-converters/block/table.ts
+++ b/packages/adapters/docx/src/element-converters/block/table.ts
@@ -21,158 +21,22 @@ import type { ElementConverterDependencies, IBlockConverter } from '../types';
 
 type DocumentElementType = TableElement;
 
-const DOCX_DEFAULT_BORDER = {
-  style: BorderStyle.SINGLE,
-  size: 4,
-  color: 'auto',
-};
-
-const DOCX_NONE_BORDER = {
-  style: BorderStyle.NONE,
-  size: 0,
-  color: 'auto',
-};
-
-const ensureZeroSizeForNoneBorders = (
-  mappedStyles: Record<string, unknown>
-): Record<string, unknown> => {
-  const normalizedStyles = { ...mappedStyles };
-
-  for (const key of ['borders', 'border'] as const) {
-    const borderGroup = normalizedStyles[key];
-    if (
-      !borderGroup ||
-      typeof borderGroup !== 'object' ||
-      Array.isArray(borderGroup)
-    ) {
-      continue;
-    }
-
-    const nextBorderGroup = { ...(borderGroup as Record<string, unknown>) };
-    let changed = false;
-
-    for (const [direction, borderValue] of Object.entries(nextBorderGroup)) {
-      if (
-        !borderValue ||
-        typeof borderValue !== 'object' ||
-        Array.isArray(borderValue)
-      ) {
-        continue;
-      }
-
-      const side = borderValue as Record<string, unknown>;
-      if (side.style === BorderStyle.NONE && side.size !== 0) {
-        nextBorderGroup[direction] = {
-          ...side,
-          size: 0,
-        };
-        changed = true;
-      }
-    }
-
-    if (changed) {
-      normalizedStyles[key] = nextBorderGroup;
-    }
-  }
-
-  return normalizedStyles;
-};
-
-const hasNoneBorderStyle = (mappedStyles: Record<string, unknown>): boolean => {
-  for (const key of ['borders', 'border'] as const) {
-    const borderGroup = mappedStyles[key];
-    if (
-      !borderGroup ||
-      typeof borderGroup !== 'object' ||
-      Array.isArray(borderGroup)
-    ) {
-      continue;
-    }
-
-    for (const borderValue of Object.values(
-      borderGroup as Record<string, unknown>
-    )) {
-      if (
-        borderValue &&
-        typeof borderValue === 'object' &&
-        !Array.isArray(borderValue) &&
-        (borderValue as Record<string, unknown>).style === BorderStyle.NONE
-      ) {
-        return true;
-      }
-    }
-  }
-
+/**
+ * Returns true if the given CSS styles declare `hidden` on the specified border side.
+ * Per CSS, `border-style: hidden` has the highest priority in border conflict resolution
+ * and suppresses adjacent visible borders in a collapsed-border table.
+ */
+const isBorderSideHidden = (
+  styles: Styles,
+  side: 'Top' | 'Right' | 'Bottom' | 'Left'
+): boolean => {
+  const sideVal = styles[`border${side}Style` as keyof Styles];
+  if (sideVal !== undefined) return sideVal === 'hidden';
+  const globalVal = styles.borderStyle;
+  if (globalVal !== undefined) return globalVal === 'hidden';
+  const border = styles.border;
+  if (border !== undefined) return /\bhidden\b/.test(String(border));
   return false;
-};
-
-const ensureHiddenTableBorders = (
-  mappedStyles: Record<string, unknown>
-): Record<string, unknown> => {
-  const normalizedStyles = ensureZeroSizeForNoneBorders(mappedStyles);
-
-  return {
-    ...normalizedStyles,
-    borders: {
-      top: { ...DOCX_NONE_BORDER },
-      bottom: { ...DOCX_NONE_BORDER },
-      left: { ...DOCX_NONE_BORDER },
-      right: { ...DOCX_NONE_BORDER },
-      insideHorizontal: { ...DOCX_NONE_BORDER },
-      insideVertical: { ...DOCX_NONE_BORDER },
-    },
-  };
-};
-
-const getBorderGroup = (
-  mappedStyles: Record<string, unknown>,
-  key: 'border' | 'borders'
-): Record<string, unknown> | undefined => {
-  const value = mappedStyles[key];
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-
-  return value as Record<string, unknown>;
-};
-
-const getBorderSide = (
-  mappedStyles: Record<string, unknown>,
-  direction: 'top' | 'right' | 'bottom' | 'left'
-): Record<string, unknown> | undefined => {
-  const borderGroup = getBorderGroup(mappedStyles, 'border');
-  if (borderGroup?.[direction] && typeof borderGroup[direction] === 'object') {
-    return borderGroup[direction] as Record<string, unknown>;
-  }
-
-  const bordersGroup = getBorderGroup(mappedStyles, 'borders');
-  if (
-    bordersGroup?.[direction] &&
-    typeof bordersGroup[direction] === 'object'
-  ) {
-    return bordersGroup[direction] as Record<string, unknown>;
-  }
-
-  return undefined;
-};
-
-const isNoneBorderSide = (
-  mappedStyles: Record<string, unknown>,
-  direction: 'top' | 'right' | 'bottom' | 'left'
-): boolean =>
-  getBorderSide(mappedStyles, direction)?.style === BorderStyle.NONE;
-
-const withExplicitCellBorders = (
-  mappedStyles: Record<string, unknown>,
-  border: Record<'top' | 'right' | 'bottom' | 'left', Record<string, unknown>>
-): Record<string, unknown> => {
-  const normalizedStyles = ensureZeroSizeForNoneBorders(mappedStyles);
-
-  return {
-    ...normalizedStyles,
-    border,
-    borders: border,
-  };
 };
 
 export class TableConverter implements IBlockConverter<DocumentElementType> {
@@ -194,7 +58,6 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
       ...defaultStyles?.[element.type],
       ...stylesheet.getComputedStyles(element, cascadedStyles),
     };
-
     const cascadingStyles = cascadeStyles(
       mergedStyles,
       element.scope,
@@ -208,14 +71,12 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
       stylesCol =
         (colgroupMeta?.metadata as { col: DocumentElement[] })?.col.map(
           (col) => {
-            return ensureZeroSizeForNoneBorders(
-              styleMapper.mapStyles(
-                {
-                  ...defaultStyles?.[col.type],
-                  ...stylesheet.getComputedStyles(col, cascadingStyles),
-                },
-                col
-              )
+            return styleMapper.mapStyles(
+              {
+                ...defaultStyles?.[col.type],
+                ...stylesheet.getComputedStyles(col, cascadingStyles),
+              },
+              col
             );
           }
         ) ?? [];
@@ -314,57 +175,28 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
         }
       }
     }
-    // Build the TableRows objects
-    const tableRows: TableRow[] = [];
-    const mappedTableStyles = ensureZeroSizeForNoneBorders(
-      styleMapper.mapStyles({ ...mergedStyles, ...element.styles }, element)
-    );
-    const hiddenTableTop = isNoneBorderSide(mappedTableStyles, 'top');
-    const hiddenTableRight = isNoneBorderSide(mappedTableStyles, 'right');
-    const hiddenTableBottom = isNoneBorderSide(mappedTableStyles, 'bottom');
-    const hiddenTableLeft = isNoneBorderSide(mappedTableStyles, 'left');
-    const cellStyleCache = new Map<DocumentElement, Record<string, unknown>>();
-    const getMappedCellStyles = (
-      cell: DocumentElement
-    ): Record<string, unknown> => {
-      const cached = cellStyleCache.get(cell);
-      if (cached) {
-        return cached;
-      }
 
-      const mappedCellStyles = ensureZeroSizeForNoneBorders(
-        styleMapper.mapStyles(
-          {
-            ...stylesheet.getMatchedStyles(cell),
-            ...defaultStyles?.[cell.type],
-            ...cell.styles,
-          },
-          cell
-        )
-      );
-
-      cellStyleCache.set(cell, mappedCellStyles);
-      return mappedCellStyles;
-    };
-
-    const hasAnyHiddenCellBorders = element.rows.some((row) => {
-      return row.cells.some((cell) =>
-        hasNoneBorderStyle(getMappedCellStyles(cell))
-      );
+    console.debug('[table-border] table raw styles:', {
+      ...mergedStyles,
+      ...element.styles,
     });
 
-    const getNeighborMappedStyles = (
-      rowIndex: number,
-      columnIndex: number
-    ): Record<string, unknown> | undefined => {
-      const neighbor = grid[rowIndex]?.[columnIndex];
-      if (!neighbor?.cell) {
-        return undefined;
-      }
-
-      return getMappedCellStyles(neighbor.cell);
+    // Helper to get the merged raw CSS styles for any grid cell (used for adjacent hidden resolution)
+    const getGridCellRawStyles = (
+      gridCell: (typeof grid)[0][0] | undefined
+    ): Styles | null => {
+      if (!gridCell?.cell) return null;
+      return {
+        ...(defaultStyles?.[gridCell.cell.type] ?? {}),
+        ...stylesheet.getMatchedStyles(gridCell.cell),
+        ...gridCell.cell.styles,
+      } as Styles;
     };
 
+    const NONE_BORDER = { style: BorderStyle.NONE, size: 0, color: 'auto' };
+
+    // Build the TableRows objects
+    const tableRows: TableRow[] = [];
     for (let i = 0; i < numRows; i++) {
       const cells: TableCell[] = [];
       let j = 0;
@@ -409,6 +241,7 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
                 ...stylesheet.getMatchedStyles(originalCell),
               }
             : {};
+
           const cellContent = originalCell
             ? converter.convertToBlocks({
                 element: originalCell,
@@ -440,109 +273,63 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
                 },
               })
             : [new Paragraph('')];
+          const docxCellStyles = styleMapper.mapStyles(
+            {
+              ...(originalCell
+                ? {
+                    ...stylesheet?.getMatchedStyles(originalCell),
+                    ...defaultStyles?.[originalCell.type],
+                  }
+                : {}),
+              ...originalCell?.styles,
+            },
+            originalCell!
+          ) as Record<string, unknown>;
 
-          let mappedCellStyles = originalCell
-            ? getMappedCellStyles(originalCell)
-            : {};
-
-          if (hasAnyHiddenCellBorders && originalCell) {
-            const topNeighborHidden = Array.from({ length: colSpan }).some(
-              (_, offset) => {
-                const neighborStyles = getNeighborMappedStyles(
-                  i - 1,
-                  j + offset
-                );
-                return neighborStyles
-                  ? isNoneBorderSide(neighborStyles, 'bottom')
-                  : false;
-              }
-            );
-            const rightNeighborHidden = Array.from({ length: rowSpan }).some(
-              (_, offset) => {
-                const neighborStyles = getNeighborMappedStyles(
-                  i + offset,
-                  j + colSpan
-                );
-                return neighborStyles
-                  ? isNoneBorderSide(neighborStyles, 'left')
-                  : false;
-              }
-            );
-            const bottomNeighborHidden = Array.from({ length: colSpan }).some(
-              (_, offset) => {
-                const neighborStyles = getNeighborMappedStyles(
-                  i + rowSpan,
-                  j + offset
-                );
-                return neighborStyles
-                  ? isNoneBorderSide(neighborStyles, 'top')
-                  : false;
-              }
-            );
-            const leftNeighborHidden = Array.from({ length: rowSpan }).some(
-              (_, offset) => {
-                const neighborStyles = getNeighborMappedStyles(
-                  i + offset,
-                  j - 1
-                );
-                return neighborStyles
-                  ? isNoneBorderSide(neighborStyles, 'right')
-                  : false;
-              }
-            );
-
-            mappedCellStyles = withExplicitCellBorders(mappedCellStyles, {
-              top:
-                isNoneBorderSide(mappedCellStyles, 'top') ||
-                topNeighborHidden ||
-                (i === 0 && hiddenTableTop)
-                  ? { ...DOCX_NONE_BORDER }
-                  : {
-                      ...(getBorderSide(mappedCellStyles, 'top') ??
-                        DOCX_DEFAULT_BORDER),
-                    },
-              right:
-                isNoneBorderSide(mappedCellStyles, 'right') ||
-                rightNeighborHidden ||
-                (j + colSpan >= effectiveNumCols && hiddenTableRight)
-                  ? { ...DOCX_NONE_BORDER }
-                  : {
-                      ...(getBorderSide(mappedCellStyles, 'right') ??
-                        DOCX_DEFAULT_BORDER),
-                    },
-              bottom:
-                isNoneBorderSide(mappedCellStyles, 'bottom') ||
-                bottomNeighborHidden ||
-                (i + rowSpan >= numRows && hiddenTableBottom)
-                  ? { ...DOCX_NONE_BORDER }
-                  : {
-                      ...(getBorderSide(mappedCellStyles, 'bottom') ??
-                        DOCX_DEFAULT_BORDER),
-                    },
-              left:
-                isNoneBorderSide(mappedCellStyles, 'left') ||
-                leftNeighborHidden ||
-                (j === 0 && hiddenTableLeft)
-                  ? { ...DOCX_NONE_BORDER }
-                  : {
-                      ...(getBorderSide(mappedCellStyles, 'left') ??
-                        DOCX_DEFAULT_BORDER),
-                    },
-            });
+          // CSS collapsed border model: border-style: hidden on a neighbour always wins.
+          // If an adjacent cell declares hidden on its shared side, suppress our border there.
+          const adjacencyOverrides: Record<string, unknown> = {};
+          const rightNeighbor = getGridCellRawStyles(grid[i]?.[j + colSpan]);
+          if (rightNeighbor && isBorderSideHidden(rightNeighbor, 'Left')) {
+            adjacencyOverrides.right = NONE_BORDER;
+          }
+          const leftNeighbor =
+            j > 0 ? getGridCellRawStyles(grid[i]?.[j - 1]) : null;
+          if (leftNeighbor && isBorderSideHidden(leftNeighbor, 'Right')) {
+            adjacencyOverrides.left = NONE_BORDER;
+          }
+          const bottomNeighbor = getGridCellRawStyles(grid[i + rowSpan]?.[j]);
+          if (bottomNeighbor && isBorderSideHidden(bottomNeighbor, 'Top')) {
+            adjacencyOverrides.bottom = NONE_BORDER;
+          }
+          const topNeighbor =
+            i > 0 ? getGridCellRawStyles(grid[i - 1]?.[j]) : null;
+          if (topNeighbor && isBorderSideHidden(topNeighbor, 'Bottom')) {
+            adjacencyOverrides.top = NONE_BORDER;
+          }
+          if (Object.keys(adjacencyOverrides).length > 0) {
+            const existing = (docxCellStyles.borders ?? {}) as Record<
+              string,
+              unknown
+            >;
+            docxCellStyles.borders = { ...existing, ...adjacencyOverrides };
           }
 
-          cells.push(
-            new TableCell({
-              // TODO: make concurrent iterations
-              children: await cellContent,
-              columnSpan: colSpan > 1 ? colSpan : undefined,
-              verticalMerge: verticalMerge,
-              verticalAlign: VerticalAlign.CENTER,
-              ...stylesCol[j],
-              ...mappedCellStyles,
-            })
-          );
+          const newCell = new TableCell({
+            // TODO: make concurrent iterations
+            children: await cellContent,
+            columnSpan: colSpan > 1 ? colSpan : undefined,
+            verticalMerge: verticalMerge,
+            verticalAlign: VerticalAlign.CENTER,
+            ...stylesCol[j],
+            ...docxCellStyles,
+          });
+          cells.push(newCell);
           j += colSpan;
+
+          console.debug(
+            `[table-border] cell [${i},${j}], styles: ${JSON.stringify(newCell, null, 2)}`
+          );
         }
       }
       const rowElement = element.rows[i];
@@ -566,17 +353,34 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
 
     // Drop table if it has no rows
     if (tableRows.length === 0) {
+      // TODO: return captions?
       return [];
     }
 
-    const rawStyles = hasAnyHiddenCellBorders
-      ? ensureHiddenTableBorders(mappedTableStyles)
-      : mappedTableStyles;
+    const rawStyles = styleMapper.mapStyles(
+      { ...mergedStyles, ...element.styles },
+      element
+    );
+
+    // HTML default: tables have no visible borders unless explicitly styled.
+    // The docx library falls back to DEFAULT_BORDER (single, size 4) for every
+    // unspecified side in TableBorders — including insideH/V — so we must
+    // always supply an explicit all-none set and let CSS values override it.
+    const tableBorders = {
+      top: NONE_BORDER,
+      bottom: NONE_BORDER,
+      left: NONE_BORDER,
+      right: NONE_BORDER,
+      insideHorizontal: NONE_BORDER,
+      insideVertical: NONE_BORDER,
+      ...((rawStyles.borders as Record<string, unknown> | undefined) ?? {}),
+    };
 
     return [
       ...captions.filter((c) => c.side === 'top').map((c) => c.paragraph),
       new Table({
         ...rawStyles,
+        borders: tableBorders,
         rows: tableRows,
       }),
       ...captions.filter((c) => c.side === 'bottom').map((c) => c.paragraph),

--- a/packages/adapters/docx/src/element-converters/block/table.ts
+++ b/packages/adapters/docx/src/element-converters/block/table.ts
@@ -1,15 +1,6 @@
 import {
-  AttributeElement,
-  cascadeStyles,
-  computeInheritedStyles,
-  DocumentElement,
-  GridCell,
-  Styles,
-  TableElement,
-} from 'html-to-document-core';
-import { ElementConverterDependencies, IBlockConverter } from '../types';
-import {
-  FileChild,
+  BorderStyle,
+  type FileChild,
   Paragraph,
   Table,
   TableCell,
@@ -17,8 +8,172 @@ import {
   TextRun,
   VerticalAlign,
 } from 'docx';
+import {
+  type AttributeElement,
+  cascadeStyles,
+  computeInheritedStyles,
+  type DocumentElement,
+  type GridCell,
+  type Styles,
+  type TableElement,
+} from 'html-to-document-core';
+import type { ElementConverterDependencies, IBlockConverter } from '../types';
 
 type DocumentElementType = TableElement;
+
+const DOCX_DEFAULT_BORDER = {
+  style: BorderStyle.SINGLE,
+  size: 4,
+  color: 'auto',
+};
+
+const DOCX_NONE_BORDER = {
+  style: BorderStyle.NONE,
+  size: 0,
+  color: 'auto',
+};
+
+const ensureZeroSizeForNoneBorders = (
+  mappedStyles: Record<string, unknown>
+): Record<string, unknown> => {
+  const normalizedStyles = { ...mappedStyles };
+
+  for (const key of ['borders', 'border'] as const) {
+    const borderGroup = normalizedStyles[key];
+    if (
+      !borderGroup ||
+      typeof borderGroup !== 'object' ||
+      Array.isArray(borderGroup)
+    ) {
+      continue;
+    }
+
+    const nextBorderGroup = { ...(borderGroup as Record<string, unknown>) };
+    let changed = false;
+
+    for (const [direction, borderValue] of Object.entries(nextBorderGroup)) {
+      if (
+        !borderValue ||
+        typeof borderValue !== 'object' ||
+        Array.isArray(borderValue)
+      ) {
+        continue;
+      }
+
+      const side = borderValue as Record<string, unknown>;
+      if (side.style === BorderStyle.NONE && side.size !== 0) {
+        nextBorderGroup[direction] = {
+          ...side,
+          size: 0,
+        };
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      normalizedStyles[key] = nextBorderGroup;
+    }
+  }
+
+  return normalizedStyles;
+};
+
+const hasNoneBorderStyle = (mappedStyles: Record<string, unknown>): boolean => {
+  for (const key of ['borders', 'border'] as const) {
+    const borderGroup = mappedStyles[key];
+    if (
+      !borderGroup ||
+      typeof borderGroup !== 'object' ||
+      Array.isArray(borderGroup)
+    ) {
+      continue;
+    }
+
+    for (const borderValue of Object.values(
+      borderGroup as Record<string, unknown>
+    )) {
+      if (
+        borderValue &&
+        typeof borderValue === 'object' &&
+        !Array.isArray(borderValue) &&
+        (borderValue as Record<string, unknown>).style === BorderStyle.NONE
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const ensureHiddenTableBorders = (
+  mappedStyles: Record<string, unknown>
+): Record<string, unknown> => {
+  const normalizedStyles = ensureZeroSizeForNoneBorders(mappedStyles);
+
+  return {
+    ...normalizedStyles,
+    borders: {
+      top: { ...DOCX_NONE_BORDER },
+      bottom: { ...DOCX_NONE_BORDER },
+      left: { ...DOCX_NONE_BORDER },
+      right: { ...DOCX_NONE_BORDER },
+      insideHorizontal: { ...DOCX_NONE_BORDER },
+      insideVertical: { ...DOCX_NONE_BORDER },
+    },
+  };
+};
+
+const getBorderGroup = (
+  mappedStyles: Record<string, unknown>,
+  key: 'border' | 'borders'
+): Record<string, unknown> | undefined => {
+  const value = mappedStyles[key];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const getBorderSide = (
+  mappedStyles: Record<string, unknown>,
+  direction: 'top' | 'right' | 'bottom' | 'left'
+): Record<string, unknown> | undefined => {
+  const borderGroup = getBorderGroup(mappedStyles, 'border');
+  if (borderGroup?.[direction] && typeof borderGroup[direction] === 'object') {
+    return borderGroup[direction] as Record<string, unknown>;
+  }
+
+  const bordersGroup = getBorderGroup(mappedStyles, 'borders');
+  if (
+    bordersGroup?.[direction] &&
+    typeof bordersGroup[direction] === 'object'
+  ) {
+    return bordersGroup[direction] as Record<string, unknown>;
+  }
+
+  return undefined;
+};
+
+const isNoneBorderSide = (
+  mappedStyles: Record<string, unknown>,
+  direction: 'top' | 'right' | 'bottom' | 'left'
+): boolean =>
+  getBorderSide(mappedStyles, direction)?.style === BorderStyle.NONE;
+
+const withExplicitCellBorders = (
+  mappedStyles: Record<string, unknown>,
+  border: Record<'top' | 'right' | 'bottom' | 'left', Record<string, unknown>>
+): Record<string, unknown> => {
+  const normalizedStyles = ensureZeroSizeForNoneBorders(mappedStyles);
+
+  return {
+    ...normalizedStyles,
+    border,
+    borders: border,
+  };
+};
 
 export class TableConverter implements IBlockConverter<DocumentElementType> {
   public isMatch(element: DocumentElement): element is DocumentElementType {
@@ -53,12 +208,14 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
       stylesCol =
         (colgroupMeta?.metadata as { col: DocumentElement[] })?.col.map(
           (col) => {
-            return styleMapper.mapStyles(
-              {
-                ...defaultStyles?.[col.type],
-                ...stylesheet.getComputedStyles(col, cascadingStyles),
-              },
-              col
+            return ensureZeroSizeForNoneBorders(
+              styleMapper.mapStyles(
+                {
+                  ...defaultStyles?.[col.type],
+                  ...stylesheet.getComputedStyles(col, cascadingStyles),
+                },
+                col
+              )
             );
           }
         ) ?? [];
@@ -159,6 +316,55 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
     }
     // Build the TableRows objects
     const tableRows: TableRow[] = [];
+    const mappedTableStyles = ensureZeroSizeForNoneBorders(
+      styleMapper.mapStyles({ ...mergedStyles, ...element.styles }, element)
+    );
+    const hiddenTableTop = isNoneBorderSide(mappedTableStyles, 'top');
+    const hiddenTableRight = isNoneBorderSide(mappedTableStyles, 'right');
+    const hiddenTableBottom = isNoneBorderSide(mappedTableStyles, 'bottom');
+    const hiddenTableLeft = isNoneBorderSide(mappedTableStyles, 'left');
+    const cellStyleCache = new Map<DocumentElement, Record<string, unknown>>();
+    const getMappedCellStyles = (
+      cell: DocumentElement
+    ): Record<string, unknown> => {
+      const cached = cellStyleCache.get(cell);
+      if (cached) {
+        return cached;
+      }
+
+      const mappedCellStyles = ensureZeroSizeForNoneBorders(
+        styleMapper.mapStyles(
+          {
+            ...stylesheet.getMatchedStyles(cell),
+            ...defaultStyles?.[cell.type],
+            ...cell.styles,
+          },
+          cell
+        )
+      );
+
+      cellStyleCache.set(cell, mappedCellStyles);
+      return mappedCellStyles;
+    };
+
+    const hasAnyHiddenCellBorders = element.rows.some((row) => {
+      return row.cells.some((cell) =>
+        hasNoneBorderStyle(getMappedCellStyles(cell))
+      );
+    });
+
+    const getNeighborMappedStyles = (
+      rowIndex: number,
+      columnIndex: number
+    ): Record<string, unknown> | undefined => {
+      const neighbor = grid[rowIndex]?.[columnIndex];
+      if (!neighbor?.cell) {
+        return undefined;
+      }
+
+      return getMappedCellStyles(neighbor.cell);
+    };
+
     for (let i = 0; i < numRows; i++) {
       const cells: TableCell[] = [];
       let j = 0;
@@ -179,7 +385,6 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
           j++;
         } else if (gridCell.horizontal) {
           j++;
-          continue;
         } else if (gridCell.verticalMerge) {
           cells.push(
             new TableCell({
@@ -236,6 +441,96 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
               })
             : [new Paragraph('')];
 
+          let mappedCellStyles = originalCell
+            ? getMappedCellStyles(originalCell)
+            : {};
+
+          if (hasAnyHiddenCellBorders && originalCell) {
+            const topNeighborHidden = Array.from({ length: colSpan }).some(
+              (_, offset) => {
+                const neighborStyles = getNeighborMappedStyles(
+                  i - 1,
+                  j + offset
+                );
+                return neighborStyles
+                  ? isNoneBorderSide(neighborStyles, 'bottom')
+                  : false;
+              }
+            );
+            const rightNeighborHidden = Array.from({ length: rowSpan }).some(
+              (_, offset) => {
+                const neighborStyles = getNeighborMappedStyles(
+                  i + offset,
+                  j + colSpan
+                );
+                return neighborStyles
+                  ? isNoneBorderSide(neighborStyles, 'left')
+                  : false;
+              }
+            );
+            const bottomNeighborHidden = Array.from({ length: colSpan }).some(
+              (_, offset) => {
+                const neighborStyles = getNeighborMappedStyles(
+                  i + rowSpan,
+                  j + offset
+                );
+                return neighborStyles
+                  ? isNoneBorderSide(neighborStyles, 'top')
+                  : false;
+              }
+            );
+            const leftNeighborHidden = Array.from({ length: rowSpan }).some(
+              (_, offset) => {
+                const neighborStyles = getNeighborMappedStyles(
+                  i + offset,
+                  j - 1
+                );
+                return neighborStyles
+                  ? isNoneBorderSide(neighborStyles, 'right')
+                  : false;
+              }
+            );
+
+            mappedCellStyles = withExplicitCellBorders(mappedCellStyles, {
+              top:
+                isNoneBorderSide(mappedCellStyles, 'top') ||
+                topNeighborHidden ||
+                (i === 0 && hiddenTableTop)
+                  ? { ...DOCX_NONE_BORDER }
+                  : {
+                      ...(getBorderSide(mappedCellStyles, 'top') ??
+                        DOCX_DEFAULT_BORDER),
+                    },
+              right:
+                isNoneBorderSide(mappedCellStyles, 'right') ||
+                rightNeighborHidden ||
+                (j + colSpan >= effectiveNumCols && hiddenTableRight)
+                  ? { ...DOCX_NONE_BORDER }
+                  : {
+                      ...(getBorderSide(mappedCellStyles, 'right') ??
+                        DOCX_DEFAULT_BORDER),
+                    },
+              bottom:
+                isNoneBorderSide(mappedCellStyles, 'bottom') ||
+                bottomNeighborHidden ||
+                (i + rowSpan >= numRows && hiddenTableBottom)
+                  ? { ...DOCX_NONE_BORDER }
+                  : {
+                      ...(getBorderSide(mappedCellStyles, 'bottom') ??
+                        DOCX_DEFAULT_BORDER),
+                    },
+              left:
+                isNoneBorderSide(mappedCellStyles, 'left') ||
+                leftNeighborHidden ||
+                (j === 0 && hiddenTableLeft)
+                  ? { ...DOCX_NONE_BORDER }
+                  : {
+                      ...(getBorderSide(mappedCellStyles, 'left') ??
+                        DOCX_DEFAULT_BORDER),
+                    },
+            });
+          }
+
           cells.push(
             new TableCell({
               // TODO: make concurrent iterations
@@ -244,18 +539,7 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
               verticalMerge: verticalMerge,
               verticalAlign: VerticalAlign.CENTER,
               ...stylesCol[j],
-              ...styleMapper.mapStyles(
-                {
-                  ...(originalCell
-                    ? {
-                        ...stylesheet?.getMatchedStyles(originalCell),
-                        ...defaultStyles?.[originalCell.type],
-                      }
-                    : {}),
-                  ...originalCell?.styles,
-                },
-                originalCell!
-              ),
+              ...mappedCellStyles,
             })
           );
           j += colSpan;
@@ -282,14 +566,12 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
 
     // Drop table if it has no rows
     if (tableRows.length === 0) {
-      // TODO: return captions?
       return [];
     }
 
-    const rawStyles = styleMapper.mapStyles(
-      { ...mergedStyles, ...element.styles },
-      element
-    );
+    const rawStyles = hasAnyHiddenCellBorders
+      ? ensureHiddenTableBorders(mappedTableStyles)
+      : mappedTableStyles;
 
     return [
       ...captions.filter((c) => c.side === 'top').map((c) => c.paragraph),

--- a/packages/adapters/docx/src/element-converters/block/table.ts
+++ b/packages/adapters/docx/src/element-converters/block/table.ts
@@ -237,31 +237,30 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
                 ...stylesheet.getMatchedStyles(originalCell),
               }
             : {};
+          const cascadedCellStyles = originalCell
+            ? computeInheritedStyles({
+                parentStyles: {
+                  ...originalCellMatchedStyles,
+                  ...stylesCol[j],
+                  ...originalCell.styles,
+                },
+                parentScope: 'tableCell',
+                childScope: 'block',
+                metaRegistry: styleMeta,
+              })
+            : {};
 
           const cellContent = originalCell
             ? converter.convertToBlocks({
                 element: originalCell,
                 stylesheet,
-                cascadedStyles: computeInheritedStyles({
-                  parentStyles: {
-                    ...originalCellMatchedStyles,
-                    ...stylesCol[j],
-                    ...originalCell.styles,
-                  },
-                  parentScope: 'tableCell',
-                  childScope: 'block',
-                  metaRegistry: styleMeta,
-                }),
+                cascadedStyles: cascadedCellStyles,
                 wrapInlineElements: (inlines) => {
                   return [
                     new Paragraph({
                       children: inlines,
                       ...styleMapper.mapStyles(
-                        {
-                          ...originalCellMatchedStyles,
-                          ...stylesCol[j],
-                          ...originalCell.styles,
-                        },
+                        cascadedCellStyles,
                         originalCell
                       ),
                     }),

--- a/packages/adapters/docx/src/element-converters/block/table.ts
+++ b/packages/adapters/docx/src/element-converters/block/table.ts
@@ -32,6 +32,7 @@ const isBorderSideHidden = (
 ): boolean => {
   const sideVal = styles[`border${side}Style` as keyof Styles];
   if (sideVal !== undefined) return sideVal === 'hidden';
+  // Consider removing the following checks as we may assume the styles to already be expanded
   const globalVal = styles.borderStyle;
   if (globalVal !== undefined) return globalVal === 'hidden';
   const border = styles.border;

--- a/packages/adapters/docx/src/element-converters/block/table.ts
+++ b/packages/adapters/docx/src/element-converters/block/table.ts
@@ -1,3 +1,4 @@
+import { createBaseParagraphElement } from '../../docx-stylesheet';
 import {
   BorderStyle,
   type FileChild,
@@ -13,6 +14,7 @@ import {
   cascadeStyles,
   computeInheritedStyles,
   type DocumentElement,
+  filterForScope,
   type GridCell,
   type Styles,
   type TableElement,
@@ -260,8 +262,8 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
                     new Paragraph({
                       children: inlines,
                       ...styleMapper.mapStyles(
-                        cascadedCellStyles,
-                        originalCell
+                        filterForScope(cascadedCellStyles, 'block', styleMeta),
+                        createBaseParagraphElement()
                       ),
                     }),
                   ];

--- a/packages/adapters/docx/src/element-converters/block/table.ts
+++ b/packages/adapters/docx/src/element-converters/block/table.ts
@@ -176,11 +176,6 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
       }
     }
 
-    console.debug('[table-border] table raw styles:', {
-      ...mergedStyles,
-      ...element.styles,
-    });
-
     // Helper to get the merged raw CSS styles for any grid cell (used for adjacent hidden resolution)
     const getGridCellRawStyles = (
       gridCell: (typeof grid)[0][0] | undefined
@@ -326,10 +321,6 @@ export class TableConverter implements IBlockConverter<DocumentElementType> {
           });
           cells.push(newCell);
           j += colSpan;
-
-          console.debug(
-            `[table-border] cell [${i},${j}], styles: ${JSON.stringify(newCell, null, 2)}`
-          );
         }
       }
       const rowElement = element.rows[i];

--- a/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
+++ b/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
@@ -281,6 +281,8 @@ describe('PDFAdapter', () => {
 
   describe('Browser environment', () => {
     beforeEach(() => {
+      const dom = new JSDOM('<!DOCTYPE html>');
+
       // Mock browser environment
       Object.defineProperty(globalThis, 'window', {
         value: {},
@@ -300,6 +302,11 @@ describe('PDFAdapter', () => {
             innerHTML: '',
           }),
         },
+        writable: true,
+      });
+
+      Object.defineProperty(globalThis, 'DOMParser', {
+        value: dom.window.DOMParser,
         writable: true,
       });
     });
@@ -377,6 +384,62 @@ describe('PDFAdapter', () => {
       // expect(mockDocxAdapter.convert).toHaveBeenCalledWith(elements);
       // expect(mockMammoth.convertToHtml).toHaveBeenCalled();
       // expect(result).toBeInstanceOf(Blob);
+    });
+
+    it('passes hidden table perimeter borders through serialized HTML for browser PDF conversion', async () => {
+      const elements: DocumentElement[] = [
+        {
+          type: 'table',
+          styles: { borderStyle: 'hidden' },
+          attributes: {},
+          rows: [
+            {
+              type: 'table-row',
+              attributes: {},
+              styles: {},
+              cells: [
+                {
+                  type: 'table-cell',
+                  content: [{ type: 'text', text: 'A' }],
+                  styles: {},
+                  attributes: {},
+                },
+                {
+                  type: 'table-cell',
+                  content: [{ type: 'text', text: 'B' }],
+                  styles: {},
+                  attributes: {},
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const mockOutputPdf = (vi.fn() as any).mockResolvedValue(
+        new Blob(['%PDF-mock'], { type: 'application/pdf' })
+      );
+      const mockInstance = {
+        set: vi.fn().mockReturnThis(),
+        from: vi.fn().mockReturnThis(),
+        outputPdf: mockOutputPdf,
+      };
+      mockHtml2pdf.mockReturnValue(mockInstance);
+
+      await adapter.convert(elements);
+
+      expect(mockHtml2pdf).toHaveBeenCalled();
+      expect(mockInstance.from).toHaveBeenCalledTimes(1);
+
+      const html = mockInstance.from.mock.calls[0]?.[0];
+      expect(typeof html).toBe('string');
+      expect(html).toContain('<table style="border-style: hidden;">');
+      expect(html).toContain(
+        '<td style="border-top-style: hidden; border-left-style: hidden; border-bottom-style: hidden;">A</td>'
+      );
+      expect(html).toContain(
+        '<td style="border-top-style: hidden; border-bottom-style: hidden; border-right-style: hidden;">B</td>'
+      );
     });
   });
 

--- a/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
+++ b/packages/adapters/pdf/__tests__/pdf.adapter.test.ts
@@ -385,62 +385,6 @@ describe('PDFAdapter', () => {
       // expect(mockMammoth.convertToHtml).toHaveBeenCalled();
       // expect(result).toBeInstanceOf(Blob);
     });
-
-    it('passes hidden table perimeter borders through serialized HTML for browser PDF conversion', async () => {
-      const elements: DocumentElement[] = [
-        {
-          type: 'table',
-          styles: { borderStyle: 'hidden' },
-          attributes: {},
-          rows: [
-            {
-              type: 'table-row',
-              attributes: {},
-              styles: {},
-              cells: [
-                {
-                  type: 'table-cell',
-                  content: [{ type: 'text', text: 'A' }],
-                  styles: {},
-                  attributes: {},
-                },
-                {
-                  type: 'table-cell',
-                  content: [{ type: 'text', text: 'B' }],
-                  styles: {},
-                  attributes: {},
-                },
-              ],
-            },
-          ],
-        },
-      ];
-
-      const mockOutputPdf = (vi.fn() as any).mockResolvedValue(
-        new Blob(['%PDF-mock'], { type: 'application/pdf' })
-      );
-      const mockInstance = {
-        set: vi.fn().mockReturnThis(),
-        from: vi.fn().mockReturnThis(),
-        outputPdf: mockOutputPdf,
-      };
-      mockHtml2pdf.mockReturnValue(mockInstance);
-
-      await adapter.convert(elements);
-
-      expect(mockHtml2pdf).toHaveBeenCalled();
-      expect(mockInstance.from).toHaveBeenCalledTimes(1);
-
-      const html = mockInstance.from.mock.calls[0]?.[0];
-      expect(typeof html).toBe('string');
-      expect(html).toContain('<table style="border-style: hidden;">');
-      expect(html).toContain(
-        '<td style="border-top-style: hidden; border-left-style: hidden; border-bottom-style: hidden;">A</td>'
-      );
-      expect(html).toContain(
-        '<td style="border-top-style: hidden; border-bottom-style: hidden; border-right-style: hidden;">B</td>'
-      );
-    });
   });
 
   describe('Error handling', () => {

--- a/packages/core/__tests__/html.serializer.test.ts
+++ b/packages/core/__tests__/html.serializer.test.ts
@@ -348,45 +348,4 @@ describe('html.serializer', () => {
 
     expect(html).toContain('<p style="color: red; font-size: 12px;">Hello</p>');
   });
-
-  it('propagates hidden table outer borders to perimeter cells during serialization', async () => {
-    const elements: DocumentElement[] = [
-      {
-        type: 'table',
-        styles: { borderStyle: 'hidden' },
-        attributes: {},
-        rows: [
-          {
-            type: 'table-row',
-            styles: {},
-            attributes: {},
-            cells: [
-              {
-                type: 'table-cell',
-                content: [{ type: 'text', text: 'A' }],
-                styles: {},
-                attributes: {},
-              },
-              {
-                type: 'table-cell',
-                content: [{ type: 'text', text: 'B' }],
-                styles: {},
-                attributes: {},
-              },
-            ],
-          },
-        ],
-      },
-    ];
-
-    const html = await minifyMiddleware(toHtml(elements));
-
-    expect(html).toContain('<table style="border-style: hidden;">');
-    expect(html).toContain(
-      '<td style="border-top-style: hidden; border-left-style: hidden; border-bottom-style: hidden;">A</td>'
-    );
-    expect(html).toContain(
-      '<td style="border-top-style: hidden; border-bottom-style: hidden; border-right-style: hidden;">B</td>'
-    );
-  });
 });

--- a/packages/core/__tests__/html.serializer.test.ts
+++ b/packages/core/__tests__/html.serializer.test.ts
@@ -348,4 +348,45 @@ describe('html.serializer', () => {
 
     expect(html).toContain('<p style="color: red; font-size: 12px;">Hello</p>');
   });
+
+  it('propagates hidden table outer borders to perimeter cells during serialization', async () => {
+    const elements: DocumentElement[] = [
+      {
+        type: 'table',
+        styles: { borderStyle: 'hidden' },
+        attributes: {},
+        rows: [
+          {
+            type: 'table-row',
+            styles: {},
+            attributes: {},
+            cells: [
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'A' }],
+                styles: {},
+                attributes: {},
+              },
+              {
+                type: 'table-cell',
+                content: [{ type: 'text', text: 'B' }],
+                styles: {},
+                attributes: {},
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const html = await minifyMiddleware(toHtml(elements));
+
+    expect(html).toContain('<table style="border-style: hidden;">');
+    expect(html).toContain(
+      '<td style="border-top-style: hidden; border-left-style: hidden; border-bottom-style: hidden;">A</td>'
+    );
+    expect(html).toContain(
+      '<td style="border-top-style: hidden; border-bottom-style: hidden; border-right-style: hidden;">B</td>'
+    );
+  });
 });

--- a/packages/core/__tests__/html.serializer.test.ts
+++ b/packages/core/__tests__/html.serializer.test.ts
@@ -1,9 +1,9 @@
-import { Parser } from '../src/parser';
-import { JSDOMParser } from './utils/parser.helper';
-import { toHtml } from '../src/utils/html.serializer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { minifyMiddleware } from '../src/middleware/minify.middleware';
-import { DocumentElement } from '../src/types';
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { Parser } from '../src/parser';
+import type { DocumentElement } from '../src/types';
+import { toHtml } from '../src/utils/html.serializer';
+import { JSDOMParser } from './utils/parser.helper';
 
 describe('html.serializer', () => {
   let parser: Parser;
@@ -163,12 +163,12 @@ describe('html.serializer', () => {
 <li>Unordered item three with <strong>bold</strong> and <span style="color: green;">green</span> text.</li>
 </ul>
 <h2>Table</h2>
-<table style="border-collapse: collapse; width: 100%;" border="1">
+<table style="border-collapse: collapse; width: 100%; border-style: solid; border-width: 1px;" border="1">
 <thead>
 <tr>
-<th style="background-color: #f0f0f0;">Feature</th>
-<th>Description</th>
-<th colspan="2">Example</th>
+<th style="background-color: #f0f0f0; border-style: solid; border-width: 1px;">Feature</th>
+<th style="border-style: solid; border-width: 1px;">Description</th>
+<th colspan="2" style="border-style: solid; border-width: 1px;">Example</th>
 </tr>
 </thead>
 <tbody>

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,650 +1,685 @@
+import type {
+	DocumentElement,
+	IDOMParser,
+	ListItemElement,
+	TableCellElement,
+	TableRowElement,
+	TagHandler,
+	TagHandlerObject,
+	TagHandlerOptions,
+} from "./types";
 import {
-  extractAttributesToMetadata,
-  parseAttributes,
-  parseStyles,
-} from './utils/html.utils';
-import {
-  DocumentElement,
-  IDOMParser,
-  TableCellElement,
-  TableRowElement,
-  TagHandler,
-  TagHandlerObject,
-  TagHandlerOptions,
-  ListItemElement,
-} from './types';
+	extractAttributesToMetadata,
+	parseAttributes,
+	parseStyles,
+} from "./utils/html.utils";
 
 class NativeParser implements IDOMParser {
-  parse(html: string): Document {
-    const parser = new DOMParser();
-    return parser.parseFromString(html, 'text/html');
-  }
+	parse(html: string): Document {
+		const parser = new DOMParser();
+		return parser.parseFromString(html, "text/html");
+	}
 }
 
 const getListLevel = (tagName: string, options: TagHandlerOptions) => {
-  const isList = tagName === 'ul' || tagName === 'ol' || tagName === 'li';
-  const newLevel =
-    options &&
-    options.metadata &&
-    typeof options.metadata.level !== 'undefined' &&
-    typeof options.metadata.level === 'string'
-      ? tagName === 'li'
-        ? (parseInt(options.metadata.level || '0') + 1).toString()
-        : options.metadata.level
-      : '0';
-  return { isList, newLevel };
+	const isList = tagName === "ul" || tagName === "ol" || tagName === "li";
+	const newLevel =
+		options &&
+		options.metadata &&
+		typeof options.metadata.level !== "undefined" &&
+		typeof options.metadata.level === "string"
+			? tagName === "li"
+				? (parseInt(options.metadata.level || "0") + 1).toString()
+				: options.metadata.level
+			: "0";
+	return { isList, newLevel };
 };
 
 // @ToDo: Handle passing of options for tag handlers and maybe Middleware
 export class Parser {
-  private _tagHandlers: Map<string, TagHandler>;
-  private _domParser: IDOMParser;
-  private _defaultAttributes: Map<
-    keyof HTMLElementTagNameMap,
-    Record<string, string | number>
-  >;
+	private _tagHandlers: Map<string, TagHandler>;
+	private _domParser: IDOMParser;
+	private _defaultAttributes: Map<
+		keyof HTMLElementTagNameMap,
+		Record<string, string | number>
+	>;
 
-  constructor(
-    tagHandlers?: readonly TagHandlerObject[],
-    domParser?: IDOMParser,
-    defaultAttributes: readonly {
-      key: keyof HTMLElementTagNameMap;
-      attributes: Record<string, string | number>;
-    }[] = []
-  ) {
-    this._domParser = domParser || new NativeParser();
-    this._tagHandlers = new Map();
-    this._defaultAttributes = new Map();
-    // Add default handlers
-    this._tagHandlers.set('table', this._parseTable.bind(this));
-    this._tagHandlers.set('thead', this._parseTableContainers.bind(this));
-    this._tagHandlers.set('tbody', this._parseTableContainers.bind(this));
-    this._tagHandlers.set('tfoot', this._parseTableContainers.bind(this));
-    if (tagHandlers && tagHandlers.length > 0) {
-      tagHandlers.forEach((tHandler) => {
-        this._tagHandlers.set(tHandler.key, tHandler.handler);
-      });
-    }
+	constructor(
+		tagHandlers?: readonly TagHandlerObject[],
+		domParser?: IDOMParser,
+		defaultAttributes: readonly {
+			key: keyof HTMLElementTagNameMap;
+			attributes: Record<string, string | number>;
+		}[] = [],
+	) {
+		this._domParser = domParser || new NativeParser();
+		this._tagHandlers = new Map();
+		this._defaultAttributes = new Map();
+		// Add default handlers
+		this._tagHandlers.set("table", this._parseTable.bind(this));
+		this._tagHandlers.set("thead", this._parseTableContainers.bind(this));
+		this._tagHandlers.set("tbody", this._parseTableContainers.bind(this));
+		this._tagHandlers.set("tfoot", this._parseTableContainers.bind(this));
+		if (tagHandlers && tagHandlers.length > 0) {
+			tagHandlers.forEach((tHandler) => {
+				this._tagHandlers.set(tHandler.key, tHandler.handler);
+			});
+		}
 
-    defaultAttributes.forEach((attribute) => {
-      this._defaultAttributes.set(attribute.key, attribute.attributes);
-    });
-    this._parseElement = this._parseElement.bind(this);
-    this._parseDocumentToElements = this._parseDocumentToElements.bind(this);
-    this._defaultHandler = this._defaultHandler.bind(this);
-  }
+		defaultAttributes.forEach((attribute) => {
+			this._defaultAttributes.set(attribute.key, attribute.attributes);
+		});
+		this._parseElement = this._parseElement.bind(this);
+		this._parseDocumentToElements = this._parseDocumentToElements.bind(this);
+		this._defaultHandler = this._defaultHandler.bind(this);
+	}
 
-  public registerTagHandler(tag: string, handler: TagHandler) {
-    // They are case insensitive
-    this._tagHandlers.set(tag.toLowerCase(), handler);
-  }
+	public registerTagHandler(tag: string, handler: TagHandler) {
+		// They are case insensitive
+		this._tagHandlers.set(tag.toLowerCase(), handler);
+	}
 
-  parse(html: string) {
-    return this.parseDocument(this.parseDocumentSource(html));
-  }
+	parse(html: string) {
+		return this.parseDocument(this.parseDocumentSource(html));
+	}
 
-  public parseDocumentSource(html: string): Document {
-    return this._domParser.parse(html);
-  }
+	public parseDocumentSource(html: string): Document {
+		return this._domParser.parse(html);
+	}
 
-  public parseDocument(document: Document) {
-    const tree = this._parseDocumentToElements(document);
-    return tree;
-  }
+	public parseDocument(document: Document) {
+		const tree = this._parseDocumentToElements(document);
+		return tree;
+	}
 
-  private _parseRow(
-    tr: HTMLElement,
-    options: TagHandlerOptions = {}
-  ): TableRowElement {
-    const cells: TableCellElement[] = [];
-    const rowStyles = { ...options.styles, ...parseStyles(tr) };
-    const rowAttrs = { ...options.attributes, ...parseAttributes(tr) };
+	private _parseRow(
+		tr: HTMLElement,
+		options: TagHandlerOptions = {},
+	): TableRowElement {
+		const cells: TableCellElement[] = [];
+		const rowStyles = { ...options.styles, ...parseStyles(tr) };
+		const rowAttrs = { ...options.attributes, ...parseAttributes(tr) };
 
-    Array.from(tr.children)
-      .filter((c): c is HTMLElement =>
-        ['td', 'th'].includes(c.tagName.toLowerCase())
-      )
-      .forEach((cell) => {
-        const isHeader = cell.tagName.toLowerCase() === 'th';
-        // parse children of the cell
-        const content = Array.from(cell.childNodes).flatMap((node) => {
-          const parsed = this._parseElement(
-            node,
-            this._tagHandlers.get(node.nodeName.toLowerCase()) ??
-              this._defaultHandler
-          );
-          // flatten fragments
-          return parsed;
-        });
+		Array.from(tr.children)
+			.filter((c): c is HTMLElement =>
+				["td", "th"].includes(c.tagName.toLowerCase()),
+			)
+			.forEach((cell) => {
+				const isHeader = cell.tagName.toLowerCase() === "th";
+				// parse children of the cell
+				const content = Array.from(cell.childNodes).flatMap((node) => {
+					const parsed = this._parseElement(
+						node,
+						this._tagHandlers.get(node.nodeName.toLowerCase()) ??
+							this._defaultHandler,
+					);
+					// flatten fragments
+					return parsed;
+				});
 
-        const cs = parseStyles(cell);
-        const ca = parseAttributes(cell);
-        const da =
-          this._defaultAttributes.get(
-            cell.tagName.toLowerCase() as keyof HTMLElementTagNameMap
-          ) || {};
-        const colspan = Number(
-          cell.getAttribute('colspan') || da['colspan'] || 1
-        );
-        const rowspan = Number(
-          cell.getAttribute('rowspan') || da['rowspan'] || 1
-        );
+				const cs = parseStyles(cell);
+				const ca = parseAttributes(cell);
+				const da =
+					this._defaultAttributes.get(
+						cell.tagName.toLowerCase() as keyof HTMLElementTagNameMap,
+					) || {};
+				const colspan = Number(
+					cell.getAttribute("colspan") || da["colspan"] || 1,
+				);
+				const rowspan = Number(
+					cell.getAttribute("rowspan") || da["rowspan"] || 1,
+				);
 
-        cells.push({
-          type: 'table-cell',
-          content,
-          styles: cs,
-          attributes: { ...da, ...ca },
-          metadata: {
-            tagName: isHeader ? 'th' : 'td',
-          },
-          colspan,
-          rowspan,
-          scope: 'tableCell',
-        });
-      });
+				cells.push({
+					type: "table-cell",
+					content,
+					styles: cs,
+					attributes: { ...da, ...ca },
+					metadata: {
+						tagName: isHeader ? "th" : "td",
+					},
+					colspan,
+					rowspan,
+					scope: "tableCell",
+				});
+			});
 
-    return {
-      type: 'table-row',
-      cells,
-      styles: rowStyles,
-      attributes: rowAttrs,
-      scope: 'tableRow',
-      metadata: {
-        tagName: 'tr',
-      },
-    };
-  }
+		return {
+			type: "table-row",
+			cells,
+			styles: rowStyles,
+			attributes: rowAttrs,
+			scope: "tableRow",
+			metadata: {
+				tagName: "tr",
+			},
+		};
+	}
 
-  private _parseElement(
-    element: HTMLElement | ChildNode,
-    handler: TagHandler,
-    options: TagHandlerOptions = {}
-  ): DocumentElement | DocumentElement[] {
-    if (element.nodeType === 3) {
-      return {
-        type: 'text',
-        text: element.textContent || '',
-        ...options,
-      };
-    }
-    let styles = parseStyles(element as HTMLElement);
-    let attributes = parseAttributes(element as HTMLElement);
+	private _parseElement(
+		element: HTMLElement | ChildNode,
+		handler: TagHandler,
+		options: TagHandlerOptions = {},
+	): DocumentElement | DocumentElement[] {
+		if (element.nodeType === 3) {
+			return {
+				type: "text",
+				text: element.textContent || "",
+				...options,
+			};
+		}
+		let styles = parseStyles(element as HTMLElement);
+		let attributes = parseAttributes(element as HTMLElement);
 
-    // Add default attributes
-    attributes = {
-      ...(this._defaultAttributes.get(
-        (
-          element as HTMLElement
-        ).tagName.toLowerCase() as keyof HTMLElementTagNameMap
-      ) ?? {}),
-      ...options.attributes,
-      ...attributes,
-    };
+		// Add default attributes
+		attributes = {
+			...(this._defaultAttributes.get(
+				(
+					element as HTMLElement
+				).tagName.toLowerCase() as keyof HTMLElementTagNameMap,
+			) ?? {}),
+			...options.attributes,
+			...attributes,
+		};
 
-    styles = {
-      ...options.styles,
-      ...styles,
-    };
+		styles = {
+			...options.styles,
+			...styles,
+		};
 
-    // Extract children
-    let children: DocumentElement[] | undefined;
-    const tagName = (element as HTMLElement).nodeName.toLowerCase();
-    const shouldWalk =
-      tagName === 'div' ||
-      !(
-        element.childNodes.length === 1 && element.childNodes[0]?.nodeType === 3
-      );
-    if (shouldWalk) {
-      const { isList, newLevel } = getListLevel(tagName, options);
+		// Extract children
+		let children: DocumentElement[] | undefined;
+		const tagName = (element as HTMLElement).nodeName.toLowerCase();
+		const shouldWalk =
+			tagName === "div" ||
+			!(
+				element.childNodes.length === 1 && element.childNodes[0]?.nodeType === 3
+			);
+		if (shouldWalk) {
+			const { isList, newLevel } = getListLevel(tagName, options);
 
-      children = Array.from(element.childNodes)
-        .map((child) => {
-          const key = child.nodeName.toLowerCase();
-          return this._parseElement(
-            child,
-            this._tagHandlers.get(key) ?? this._defaultHandler,
-            isList
-              ? {
-                  metadata: {
-                    level: newLevel,
-                  },
-                }
-              : {}
-          );
-        })
-        .flat();
-    }
-    // Extract text
-    const text =
-      children === undefined
-        ? element.textContent
-          ? element.textContent
-          : undefined
-        : undefined;
-    const result = handler(element as HTMLElement, {
-      ...options,
-      styles,
-      attributes,
-      content: children,
-      text,
-      metadata: {
-        ...(options.metadata ?? {}),
-        tagName,
-      },
-    });
+			children = Array.from(element.childNodes).flatMap((child) => {
+				const key = child.nodeName.toLowerCase();
+				return this._parseElement(
+					child,
+					this._tagHandlers.get(key) ?? this._defaultHandler,
+					isList
+						? {
+								metadata: {
+									level: newLevel,
+								},
+							}
+						: {},
+				);
+			});
+		}
+		// Extract text
+		const text =
+			children === undefined
+				? element.textContent
+					? element.textContent
+					: undefined
+				: undefined;
+		const result = handler(element as HTMLElement, {
+			...options,
+			styles,
+			attributes,
+			content: children,
+			text,
+			metadata: {
+				...(options.metadata ?? {}),
+				tagName,
+			},
+		});
 
-    // helper to guarantee tagName is always present
-    const ensureTagName = <T extends DocumentElement>(el: T): T => {
-      el.metadata = { tagName, ...(el.metadata ?? {}) };
-      return el;
-    };
+		// helper to guarantee tagName is always present
+		const ensureTagName = <T extends DocumentElement>(el: T): T => {
+			el.metadata = { tagName, ...(el.metadata ?? {}) };
+			return el;
+		};
 
-    if (Array.isArray(result)) {
-      return result.map((el) => extractAttributesToMetadata(ensureTagName(el)));
-    }
+		if (Array.isArray(result)) {
+			return result.map((el) => extractAttributesToMetadata(ensureTagName(el)));
+		}
 
-    ensureTagName(result);
+		ensureTagName(result);
 
-    if (result.type === 'fragment') {
-      const wrapperStyles = result.styles || {};
-      const wrapperAttrs = result.attributes || {};
-      return (result.content || []).map((el) => ({
-        ...el,
-        styles: { ...wrapperStyles, ...el.styles },
-        attributes: { ...wrapperAttrs, ...el.attributes },
-      }));
-    }
+		if (result.type === "fragment") {
+			const wrapperStyles = result.styles || {};
+			const wrapperAttrs = result.attributes || {};
+			return (result.content || []).map((el) => ({
+				...el,
+				styles: { ...wrapperStyles, ...el.styles },
+				attributes: { ...wrapperAttrs, ...el.attributes },
+			}));
+		}
 
-    return extractAttributesToMetadata(result);
-  }
+		return extractAttributesToMetadata(result);
+	}
 
-  private _parseTableContainers(element: HTMLElement): TableRowElement[] {
-    const rows: TableRowElement[] = [];
-    const section = element.tagName.toLowerCase();
+	private _parseTableContainers(element: HTMLElement): TableRowElement[] {
+		const rows: TableRowElement[] = [];
+		const section = element.tagName.toLowerCase();
 
-    Array.from(element.children)
-      .filter((c): c is HTMLElement => c.tagName.toLowerCase() === 'tr')
-      .forEach((tr) => {
-        const row = this._parseRow(tr);
-        row.metadata = {
-          ...(row.metadata ?? {}),
-          section,
-        };
-        rows.push(row);
-      });
+		Array.from(element.children)
+			.filter((c): c is HTMLElement => c.tagName.toLowerCase() === "tr")
+			.forEach((tr) => {
+				const row = this._parseRow(tr);
+				row.metadata = {
+					...(row.metadata ?? {}),
+					section,
+				};
+				rows.push(row);
+			});
 
-    return rows;
-  }
+		return rows;
+	}
 
-  private _parseTable(
-    element: HTMLElement | ChildNode,
-    options: TagHandlerOptions = {}
-  ): DocumentElement {
-    const rows: TableRowElement[] = [];
-    const content: DocumentElement[] = [];
+	private _parseTable(
+		element: HTMLElement | ChildNode,
+		options: TagHandlerOptions = {},
+	): DocumentElement {
+		const rows: TableRowElement[] = [];
+		const content: DocumentElement[] = [];
 
-    // Fetch defaults
-    const defaultTableAttrs =
-      this._defaultAttributes.get(
-        (
-          element as HTMLElement
-        ).tagName.toLowerCase() as keyof HTMLElementTagNameMap
-      ) || {};
+		const tableEl = element as HTMLElement;
 
-    // Iterate *every* direct child of <table> in source order
-    Array.from((element as HTMLElement).childNodes).forEach((node) => {
-      if (node.nodeType !== 1) return; // skip text/comments
-      const el = node as HTMLElement;
-      const tag = el.tagName.toLowerCase();
+		// Fetch defaults
+		const defaultTableAttrs =
+			this._defaultAttributes.get(
+				tableEl.tagName.toLowerCase() as keyof HTMLElementTagNameMap,
+			) || {};
 
-      const result = this._parseElement(
-        el,
-        this._tagHandlers.get(tag) ?? this._defaultHandler
-      );
+		const tableStyles = parseStyles(tableEl);
+		const tableAttrs = parseAttributes(tableEl);
 
-      if (Array.isArray(result)) {
-        rows.push(
-          ...result.filter((c): c is TableRowElement => c.type === 'table-row')
-        );
-        content.push(
-          ...result.filter((c): c is DocumentElement => c.type !== 'table-row')
-        );
-      } else {
-        if (result.type === 'table-row') {
-          rows.push(result as TableRowElement);
-        }
-        if (result.type !== 'table-row') {
-          content.push(result as DocumentElement);
-        }
-      }
-    });
-    return {
-      type: 'table',
-      rows,
-      content: content.length > 0 ? content : undefined,
-      styles: {
-        ...options.styles,
-      },
-      metadata: {
-        ...options.metadata,
-        nested: element.parentElement?.tagName.toLowerCase() === 'td',
-      },
-      attributes: {
-        ...defaultTableAttrs,
-        ...options.attributes,
-      },
-      scope: 'table',
-    };
-  }
+		// Map the deprecated HTML `border` attribute to CSS when no explicit
+		// border-style is already set via the `style` attribute.
+		// e.g. border="1" → borderStyle: 'solid', borderWidth: '1px'
+		// Per the HTML spec and browser behaviour, this also applies to all cells.
+		const borderAttr = tableAttrs["border"];
+		const borderPx = Number(borderAttr);
+		const tableBorderFromAttr =
+			borderAttr !== undefined &&
+			!tableStyles.borderStyle &&
+			!tableStyles.border &&
+			borderPx > 0;
 
-  private _parseDocumentToElements(doc: Document): DocumentElement[] {
-    const content: DocumentElement[] = [];
+		if (tableBorderFromAttr) {
+			tableStyles.borderStyle = "solid";
+			tableStyles.borderWidth = `${borderPx}px`;
+		}
 
-    doc.body.childNodes.forEach((child) => {
-      const key = child.nodeName.toLowerCase();
-      const result = this._parseElement(
-        child,
-        this._tagHandlers.get(key) ?? this._defaultHandler
-      );
-      // if (result) {
-      if (Array.isArray(result)) {
-        content.push(...result);
-      } else {
-        content.push(result);
-      }
-      // }
-    });
-    return content;
-  }
+		// Iterate *every* direct child of <table> in source order
+		Array.from(tableEl.childNodes).forEach((node) => {
+			if (node.nodeType !== 1) return; // skip text/comments
+			const el = node as HTMLElement;
+			const tag = el.tagName.toLowerCase();
 
-  private _defaultHandler(
-    element: HTMLElement | ChildNode,
-    options: TagHandlerOptions = {}
-  ): DocumentElement {
-    if (element.nodeType === 3) {
-      return {
-        type: 'text',
-        text: element.textContent || '',
-      };
-    }
-    const tag =
-      (element as HTMLElement).tagName?.toLowerCase() ||
-      (element as ChildNode).nodeName?.toLowerCase();
-    // Now just use options.text and options.content (children)
-    const text = (options.text ?? undefined) as string | undefined;
-    const children = (options.content ?? undefined) as
-      | DocumentElement[]
-      | ListItemElement[]
-      | undefined;
+			const result = this._parseElement(
+				el,
+				this._tagHandlers.get(tag) ?? this._defaultHandler,
+			);
 
-    switch (tag) {
-      case 'p':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
-      case 'div':
-        return { type: 'fragment', text, content: children, ...options };
-      case 'strong':
-      case 'b':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          ...options,
-          scope: 'inline',
-        };
-      case 'colgroup':
-        return {
-          type: 'attribute',
-          name: 'colgroup',
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
-      case 'col':
-        return {
-          type: 'attribute',
-          name: 'col',
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
-      case 'em':
-      case 'i':
-      case 'cite':
-      case 'dfn':
-      case 'var':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
-      case 'small':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
+			if (Array.isArray(result)) {
+				rows.push(
+					...result.filter((c): c is TableRowElement => c.type === "table-row"),
+				);
+				content.push(
+					...result.filter((c): c is DocumentElement => c.type !== "table-row"),
+				);
+			} else {
+				if (result.type === "table-row") {
+					rows.push(result as TableRowElement);
+				}
+				if (result.type !== "table-row") {
+					content.push(result as DocumentElement);
+				}
+			}
+		});
 
-      case 'u':
-      case 'ins':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
+		// Propagate border attribute down to cells that don't have their own border.
+		if (tableBorderFromAttr) {
+			for (const row of rows) {
+				for (const cell of row.cells) {
+					if (!cell.styles?.borderStyle && !cell.styles?.border) {
+						cell.styles = {
+							...cell.styles,
+							borderStyle: "solid",
+							borderWidth: `${borderPx}px`,
+						};
+					}
+				}
+			}
+		}
+		return {
+			type: "table",
+			rows,
+			content: content.length > 0 ? content : undefined,
+			styles: {
+				...options.styles,
+				...tableStyles,
+			},
+			metadata: {
+				...options.metadata,
+				nested: tableEl.parentElement?.tagName.toLowerCase() === "td",
+			},
+			attributes: {
+				...defaultTableAttrs,
+				...options.attributes,
+				...tableAttrs,
+			},
+			scope: "table",
+		};
+	}
 
-      case 'hr':
-        return { type: 'line', ...options };
+	private _parseDocumentToElements(doc: Document): DocumentElement[] {
+		const content: DocumentElement[] = [];
 
-      case 'h1':
-      case 'h2':
-      case 'h3':
-        return {
-          type: 'heading',
-          level: Number(tag.slice(1)),
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
+		doc.body.childNodes.forEach((child) => {
+			const key = child.nodeName.toLowerCase();
+			const result = this._parseElement(
+				child,
+				this._tagHandlers.get(key) ?? this._defaultHandler,
+			);
+			// if (result) {
+			if (Array.isArray(result)) {
+				content.push(...result);
+			} else {
+				content.push(result);
+			}
+			// }
+		});
+		return content;
+	}
 
-      case 'ul':
-      case 'ol':
-        return {
-          type: 'list',
-          listType: tag === 'ol' ? 'ordered' : 'unordered',
-          content: children,
-          scope: 'block',
-          level:
-            typeof options.metadata?.level === 'number'
-              ? options.metadata.level
-              : parseInt(options.metadata?.level as string) || 0,
-          ...options,
-          metadata: {
-            ...options.metadata,
-            level: options.metadata?.level ?? '0',
-          },
-        };
+	private _defaultHandler(
+		element: HTMLElement | ChildNode,
+		options: TagHandlerOptions = {},
+	): DocumentElement {
+		if (element.nodeType === 3) {
+			return {
+				type: "text",
+				text: element.textContent || "",
+			};
+		}
+		const tag =
+			(element as HTMLElement).tagName?.toLowerCase() ||
+			(element as ChildNode).nodeName?.toLowerCase();
+		// Now just use options.text and options.content (children)
+		const text = (options.text ?? undefined) as string | undefined;
+		const children = (options.content ?? undefined) as
+			| DocumentElement[]
+			| ListItemElement[]
+			| undefined;
 
-      case 'li':
-        return {
-          type: 'list-item',
-          text,
-          content: children,
-          level:
-            typeof options.metadata?.level === 'number'
-              ? options.metadata.level
-              : parseInt(options.metadata?.level as string) || 0,
-          scope: 'block',
-          ...options,
-        };
+		switch (tag) {
+			case "p":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
+			case "div":
+				return { type: "fragment", text, content: children, ...options };
+			case "strong":
+			case "b":
+				return {
+					type: "text",
+					text,
+					content: children,
+					...options,
+					scope: "inline",
+				};
+			case "colgroup":
+				return {
+					type: "attribute",
+					name: "colgroup",
+					content: children,
+					scope: "inline",
+					...options,
+				};
+			case "col":
+				return {
+					type: "attribute",
+					name: "col",
+					content: children,
+					scope: "inline",
+					...options,
+				};
+			case "em":
+			case "i":
+			case "cite":
+			case "dfn":
+			case "var":
+				return {
+					type: "text",
+					text,
+					content: children,
+					scope: "inline",
+					...options,
+				};
+			case "small":
+				return {
+					type: "text",
+					text,
+					content: children,
+					scope: "inline",
+					...options,
+				};
 
-      case 'header':
-        return { type: 'header', text, content: children, ...options };
+			case "u":
+			case "ins":
+				return {
+					type: "text",
+					text,
+					content: children,
+					scope: "inline",
+					...options,
+				};
 
-      case 'address':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
+			case "hr":
+				return { type: "line", ...options };
 
-      case 'footer':
-        return { type: 'footer', text, content: children, ...options };
+			case "h1":
+			case "h2":
+			case "h3":
+				return {
+					type: "heading",
+					level: Number(tag.slice(1)),
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
 
-      case 'section':
-        if ((element as HTMLElement).classList.contains('page-break')) {
-          return { type: 'page-break', ...options };
-        }
-        if ((element as HTMLElement).classList.contains('page')) {
-          return { type: 'page', text, content: children, ...options };
-        }
-        return { type: 'fragment', text, content: children, ...options };
+			case "ul":
+			case "ol":
+				return {
+					type: "list",
+					listType: tag === "ol" ? "ordered" : "unordered",
+					content: children,
+					scope: "block",
+					level:
+						typeof options.metadata?.level === "number"
+							? options.metadata.level
+							: parseInt(options.metadata?.level as string) || 0,
+					...options,
+					metadata: {
+						...options.metadata,
+						level: options.metadata?.level ?? "0",
+					},
+				};
 
-      case 'span':
-      case 'a':
-      case 'mark':
-      case 'kbd':
-      case 'samp':
-      case 's':
-      case 'del':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
+			case "li":
+				return {
+					type: "list-item",
+					text,
+					content: children,
+					level:
+						typeof options.metadata?.level === "number"
+							? options.metadata.level
+							: parseInt(options.metadata?.level as string) || 0,
+					scope: "block",
+					...options,
+				};
 
-      case 'sup':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
+			case "header":
+				return { type: "header", text, content: children, ...options };
 
-      case 'sub':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          ...options,
-          scope: 'inline',
-        };
+			case "address":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
 
-      case 'img':
-        return {
-          type: 'image',
-          src: (element as HTMLImageElement).src,
-          scope: 'inline', // default to inline, but can be changed to block depending on context
-          ...options,
-        };
+			case "footer":
+				return { type: "footer", text, content: children, ...options };
 
-      case 'pre':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
+			case "section":
+				if ((element as HTMLElement).classList.contains("page-break")) {
+					return { type: "page-break", ...options };
+				}
+				if ((element as HTMLElement).classList.contains("page")) {
+					return { type: "page", text, content: children, ...options };
+				}
+				return { type: "fragment", text, content: children, ...options };
 
-      case 'code':
-        return {
-          type: 'text',
-          text,
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
+			case "span":
+			case "a":
+			case "mark":
+			case "kbd":
+			case "samp":
+			case "s":
+			case "del":
+				return {
+					type: "text",
+					text,
+					content: children,
+					scope: "inline",
+					...options,
+				};
 
-      case 'br':
-        return {
-          ...options,
-          type: 'text',
-          text: '',
-          metadata: { break: 1, ...options.metadata },
-          scope: 'inline',
-        };
+			case "sup":
+				return {
+					type: "text",
+					text,
+					content: children,
+					scope: "inline",
+					...options,
+				};
 
-      case 'blockquote':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
+			case "sub":
+				return {
+					type: "text",
+					text,
+					content: children,
+					...options,
+					scope: "inline",
+				};
 
-      // FIGURE and CAPTION now as paragraphs
-      case 'figure':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
+			case "img":
+				return {
+					type: "image",
+					src: (element as HTMLImageElement).src,
+					scope: "inline", // default to inline, but can be changed to block depending on context
+					...options,
+				};
 
-      case 'figcaption':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
-      case 'caption':
-        return {
-          type: 'attribute',
-          name: 'caption',
-          text,
-          content: children,
-          scope: 'inline',
-          ...options,
-        };
-      // Description list container
-      case 'dl':
-        return { type: 'fragment', text, content: children, ...options };
-      // Description term
-      case 'dt':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-          // default term style: bold
-          styles: { ...(options.styles || {}) },
-        };
-      // Description definition: indented
-      case 'dd':
-        return {
-          type: 'paragraph',
-          text,
-          content: children,
-          scope: 'block',
-          ...options,
-        };
+			case "pre":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
 
-      default:
-        return { type: 'custom', text, content: children, ...options };
-    }
-  }
+			case "code":
+				return {
+					type: "text",
+					text,
+					content: children,
+					scope: "inline",
+					...options,
+				};
+
+			case "br":
+				return {
+					...options,
+					type: "text",
+					text: "",
+					metadata: { break: 1, ...options.metadata },
+					scope: "inline",
+				};
+
+			case "blockquote":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
+
+			// FIGURE and CAPTION now as paragraphs
+			case "figure":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
+
+			case "figcaption":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
+			case "caption":
+				return {
+					type: "attribute",
+					name: "caption",
+					text,
+					content: children,
+					scope: "inline",
+					...options,
+				};
+			// Description list container
+			case "dl":
+				return { type: "fragment", text, content: children, ...options };
+			// Description term
+			case "dt":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+					// default term style: bold
+					styles: { ...(options.styles || {}) },
+				};
+			// Description definition: indented
+			case "dd":
+				return {
+					type: "paragraph",
+					text,
+					content: children,
+					scope: "block",
+					...options,
+				};
+
+			default:
+				return { type: "custom", text, content: children, ...options };
+		}
+	}
 }

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,685 +1,685 @@
 import type {
-	DocumentElement,
-	IDOMParser,
-	ListItemElement,
-	TableCellElement,
-	TableRowElement,
-	TagHandler,
-	TagHandlerObject,
-	TagHandlerOptions,
-} from "./types";
+  DocumentElement,
+  IDOMParser,
+  ListItemElement,
+  TableCellElement,
+  TableRowElement,
+  TagHandler,
+  TagHandlerObject,
+  TagHandlerOptions,
+} from './types';
 import {
-	extractAttributesToMetadata,
-	parseAttributes,
-	parseStyles,
-} from "./utils/html.utils";
+  extractAttributesToMetadata,
+  parseAttributes,
+  parseStyles,
+} from './utils/html.utils';
 
 class NativeParser implements IDOMParser {
-	parse(html: string): Document {
-		const parser = new DOMParser();
-		return parser.parseFromString(html, "text/html");
-	}
+  parse(html: string): Document {
+    const parser = new DOMParser();
+    return parser.parseFromString(html, 'text/html');
+  }
 }
 
 const getListLevel = (tagName: string, options: TagHandlerOptions) => {
-	const isList = tagName === "ul" || tagName === "ol" || tagName === "li";
-	const newLevel =
-		options &&
-		options.metadata &&
-		typeof options.metadata.level !== "undefined" &&
-		typeof options.metadata.level === "string"
-			? tagName === "li"
-				? (parseInt(options.metadata.level || "0") + 1).toString()
-				: options.metadata.level
-			: "0";
-	return { isList, newLevel };
+  const isList = tagName === 'ul' || tagName === 'ol' || tagName === 'li';
+  const newLevel =
+    options &&
+    options.metadata &&
+    typeof options.metadata.level !== 'undefined' &&
+    typeof options.metadata.level === 'string'
+      ? tagName === 'li'
+        ? (parseInt(options.metadata.level || '0') + 1).toString()
+        : options.metadata.level
+      : '0';
+  return { isList, newLevel };
 };
 
 // @ToDo: Handle passing of options for tag handlers and maybe Middleware
 export class Parser {
-	private _tagHandlers: Map<string, TagHandler>;
-	private _domParser: IDOMParser;
-	private _defaultAttributes: Map<
-		keyof HTMLElementTagNameMap,
-		Record<string, string | number>
-	>;
+  private _tagHandlers: Map<string, TagHandler>;
+  private _domParser: IDOMParser;
+  private _defaultAttributes: Map<
+    keyof HTMLElementTagNameMap,
+    Record<string, string | number>
+  >;
 
-	constructor(
-		tagHandlers?: readonly TagHandlerObject[],
-		domParser?: IDOMParser,
-		defaultAttributes: readonly {
-			key: keyof HTMLElementTagNameMap;
-			attributes: Record<string, string | number>;
-		}[] = [],
-	) {
-		this._domParser = domParser || new NativeParser();
-		this._tagHandlers = new Map();
-		this._defaultAttributes = new Map();
-		// Add default handlers
-		this._tagHandlers.set("table", this._parseTable.bind(this));
-		this._tagHandlers.set("thead", this._parseTableContainers.bind(this));
-		this._tagHandlers.set("tbody", this._parseTableContainers.bind(this));
-		this._tagHandlers.set("tfoot", this._parseTableContainers.bind(this));
-		if (tagHandlers && tagHandlers.length > 0) {
-			tagHandlers.forEach((tHandler) => {
-				this._tagHandlers.set(tHandler.key, tHandler.handler);
-			});
-		}
+  constructor(
+    tagHandlers?: readonly TagHandlerObject[],
+    domParser?: IDOMParser,
+    defaultAttributes: readonly {
+      key: keyof HTMLElementTagNameMap;
+      attributes: Record<string, string | number>;
+    }[] = []
+  ) {
+    this._domParser = domParser || new NativeParser();
+    this._tagHandlers = new Map();
+    this._defaultAttributes = new Map();
+    // Add default handlers
+    this._tagHandlers.set('table', this._parseTable.bind(this));
+    this._tagHandlers.set('thead', this._parseTableContainers.bind(this));
+    this._tagHandlers.set('tbody', this._parseTableContainers.bind(this));
+    this._tagHandlers.set('tfoot', this._parseTableContainers.bind(this));
+    if (tagHandlers && tagHandlers.length > 0) {
+      tagHandlers.forEach((tHandler) => {
+        this._tagHandlers.set(tHandler.key, tHandler.handler);
+      });
+    }
 
-		defaultAttributes.forEach((attribute) => {
-			this._defaultAttributes.set(attribute.key, attribute.attributes);
-		});
-		this._parseElement = this._parseElement.bind(this);
-		this._parseDocumentToElements = this._parseDocumentToElements.bind(this);
-		this._defaultHandler = this._defaultHandler.bind(this);
-	}
+    defaultAttributes.forEach((attribute) => {
+      this._defaultAttributes.set(attribute.key, attribute.attributes);
+    });
+    this._parseElement = this._parseElement.bind(this);
+    this._parseDocumentToElements = this._parseDocumentToElements.bind(this);
+    this._defaultHandler = this._defaultHandler.bind(this);
+  }
 
-	public registerTagHandler(tag: string, handler: TagHandler) {
-		// They are case insensitive
-		this._tagHandlers.set(tag.toLowerCase(), handler);
-	}
+  public registerTagHandler(tag: string, handler: TagHandler) {
+    // They are case insensitive
+    this._tagHandlers.set(tag.toLowerCase(), handler);
+  }
 
-	parse(html: string) {
-		return this.parseDocument(this.parseDocumentSource(html));
-	}
+  parse(html: string) {
+    return this.parseDocument(this.parseDocumentSource(html));
+  }
 
-	public parseDocumentSource(html: string): Document {
-		return this._domParser.parse(html);
-	}
+  public parseDocumentSource(html: string): Document {
+    return this._domParser.parse(html);
+  }
 
-	public parseDocument(document: Document) {
-		const tree = this._parseDocumentToElements(document);
-		return tree;
-	}
+  public parseDocument(document: Document) {
+    const tree = this._parseDocumentToElements(document);
+    return tree;
+  }
 
-	private _parseRow(
-		tr: HTMLElement,
-		options: TagHandlerOptions = {},
-	): TableRowElement {
-		const cells: TableCellElement[] = [];
-		const rowStyles = { ...options.styles, ...parseStyles(tr) };
-		const rowAttrs = { ...options.attributes, ...parseAttributes(tr) };
+  private _parseRow(
+    tr: HTMLElement,
+    options: TagHandlerOptions = {}
+  ): TableRowElement {
+    const cells: TableCellElement[] = [];
+    const rowStyles = { ...options.styles, ...parseStyles(tr) };
+    const rowAttrs = { ...options.attributes, ...parseAttributes(tr) };
 
-		Array.from(tr.children)
-			.filter((c): c is HTMLElement =>
-				["td", "th"].includes(c.tagName.toLowerCase()),
-			)
-			.forEach((cell) => {
-				const isHeader = cell.tagName.toLowerCase() === "th";
-				// parse children of the cell
-				const content = Array.from(cell.childNodes).flatMap((node) => {
-					const parsed = this._parseElement(
-						node,
-						this._tagHandlers.get(node.nodeName.toLowerCase()) ??
-							this._defaultHandler,
-					);
-					// flatten fragments
-					return parsed;
-				});
+    Array.from(tr.children)
+      .filter((c): c is HTMLElement =>
+        ['td', 'th'].includes(c.tagName.toLowerCase())
+      )
+      .forEach((cell) => {
+        const isHeader = cell.tagName.toLowerCase() === 'th';
+        // parse children of the cell
+        const content = Array.from(cell.childNodes).flatMap((node) => {
+          const parsed = this._parseElement(
+            node,
+            this._tagHandlers.get(node.nodeName.toLowerCase()) ??
+              this._defaultHandler
+          );
+          // flatten fragments
+          return parsed;
+        });
 
-				const cs = parseStyles(cell);
-				const ca = parseAttributes(cell);
-				const da =
-					this._defaultAttributes.get(
-						cell.tagName.toLowerCase() as keyof HTMLElementTagNameMap,
-					) || {};
-				const colspan = Number(
-					cell.getAttribute("colspan") || da["colspan"] || 1,
-				);
-				const rowspan = Number(
-					cell.getAttribute("rowspan") || da["rowspan"] || 1,
-				);
+        const cs = parseStyles(cell);
+        const ca = parseAttributes(cell);
+        const da =
+          this._defaultAttributes.get(
+            cell.tagName.toLowerCase() as keyof HTMLElementTagNameMap
+          ) || {};
+        const colspan = Number(
+          cell.getAttribute('colspan') || da['colspan'] || 1
+        );
+        const rowspan = Number(
+          cell.getAttribute('rowspan') || da['rowspan'] || 1
+        );
 
-				cells.push({
-					type: "table-cell",
-					content,
-					styles: cs,
-					attributes: { ...da, ...ca },
-					metadata: {
-						tagName: isHeader ? "th" : "td",
-					},
-					colspan,
-					rowspan,
-					scope: "tableCell",
-				});
-			});
+        cells.push({
+          type: 'table-cell',
+          content,
+          styles: cs,
+          attributes: { ...da, ...ca },
+          metadata: {
+            tagName: isHeader ? 'th' : 'td',
+          },
+          colspan,
+          rowspan,
+          scope: 'tableCell',
+        });
+      });
 
-		return {
-			type: "table-row",
-			cells,
-			styles: rowStyles,
-			attributes: rowAttrs,
-			scope: "tableRow",
-			metadata: {
-				tagName: "tr",
-			},
-		};
-	}
+    return {
+      type: 'table-row',
+      cells,
+      styles: rowStyles,
+      attributes: rowAttrs,
+      scope: 'tableRow',
+      metadata: {
+        tagName: 'tr',
+      },
+    };
+  }
 
-	private _parseElement(
-		element: HTMLElement | ChildNode,
-		handler: TagHandler,
-		options: TagHandlerOptions = {},
-	): DocumentElement | DocumentElement[] {
-		if (element.nodeType === 3) {
-			return {
-				type: "text",
-				text: element.textContent || "",
-				...options,
-			};
-		}
-		let styles = parseStyles(element as HTMLElement);
-		let attributes = parseAttributes(element as HTMLElement);
+  private _parseElement(
+    element: HTMLElement | ChildNode,
+    handler: TagHandler,
+    options: TagHandlerOptions = {}
+  ): DocumentElement | DocumentElement[] {
+    if (element.nodeType === 3) {
+      return {
+        type: 'text',
+        text: element.textContent || '',
+        ...options,
+      };
+    }
+    let styles = parseStyles(element as HTMLElement);
+    let attributes = parseAttributes(element as HTMLElement);
 
-		// Add default attributes
-		attributes = {
-			...(this._defaultAttributes.get(
-				(
-					element as HTMLElement
-				).tagName.toLowerCase() as keyof HTMLElementTagNameMap,
-			) ?? {}),
-			...options.attributes,
-			...attributes,
-		};
+    // Add default attributes
+    attributes = {
+      ...(this._defaultAttributes.get(
+        (
+          element as HTMLElement
+        ).tagName.toLowerCase() as keyof HTMLElementTagNameMap
+      ) ?? {}),
+      ...options.attributes,
+      ...attributes,
+    };
 
-		styles = {
-			...options.styles,
-			...styles,
-		};
+    styles = {
+      ...options.styles,
+      ...styles,
+    };
 
-		// Extract children
-		let children: DocumentElement[] | undefined;
-		const tagName = (element as HTMLElement).nodeName.toLowerCase();
-		const shouldWalk =
-			tagName === "div" ||
-			!(
-				element.childNodes.length === 1 && element.childNodes[0]?.nodeType === 3
-			);
-		if (shouldWalk) {
-			const { isList, newLevel } = getListLevel(tagName, options);
+    // Extract children
+    let children: DocumentElement[] | undefined;
+    const tagName = (element as HTMLElement).nodeName.toLowerCase();
+    const shouldWalk =
+      tagName === 'div' ||
+      !(
+        element.childNodes.length === 1 && element.childNodes[0]?.nodeType === 3
+      );
+    if (shouldWalk) {
+      const { isList, newLevel } = getListLevel(tagName, options);
 
-			children = Array.from(element.childNodes).flatMap((child) => {
-				const key = child.nodeName.toLowerCase();
-				return this._parseElement(
-					child,
-					this._tagHandlers.get(key) ?? this._defaultHandler,
-					isList
-						? {
-								metadata: {
-									level: newLevel,
-								},
-							}
-						: {},
-				);
-			});
-		}
-		// Extract text
-		const text =
-			children === undefined
-				? element.textContent
-					? element.textContent
-					: undefined
-				: undefined;
-		const result = handler(element as HTMLElement, {
-			...options,
-			styles,
-			attributes,
-			content: children,
-			text,
-			metadata: {
-				...(options.metadata ?? {}),
-				tagName,
-			},
-		});
+      children = Array.from(element.childNodes).flatMap((child) => {
+        const key = child.nodeName.toLowerCase();
+        return this._parseElement(
+          child,
+          this._tagHandlers.get(key) ?? this._defaultHandler,
+          isList
+            ? {
+                metadata: {
+                  level: newLevel,
+                },
+              }
+            : {}
+        );
+      });
+    }
+    // Extract text
+    const text =
+      children === undefined
+        ? element.textContent
+          ? element.textContent
+          : undefined
+        : undefined;
+    const result = handler(element as HTMLElement, {
+      ...options,
+      styles,
+      attributes,
+      content: children,
+      text,
+      metadata: {
+        ...(options.metadata ?? {}),
+        tagName,
+      },
+    });
 
-		// helper to guarantee tagName is always present
-		const ensureTagName = <T extends DocumentElement>(el: T): T => {
-			el.metadata = { tagName, ...(el.metadata ?? {}) };
-			return el;
-		};
+    // helper to guarantee tagName is always present
+    const ensureTagName = <T extends DocumentElement>(el: T): T => {
+      el.metadata = { tagName, ...(el.metadata ?? {}) };
+      return el;
+    };
 
-		if (Array.isArray(result)) {
-			return result.map((el) => extractAttributesToMetadata(ensureTagName(el)));
-		}
+    if (Array.isArray(result)) {
+      return result.map((el) => extractAttributesToMetadata(ensureTagName(el)));
+    }
 
-		ensureTagName(result);
+    ensureTagName(result);
 
-		if (result.type === "fragment") {
-			const wrapperStyles = result.styles || {};
-			const wrapperAttrs = result.attributes || {};
-			return (result.content || []).map((el) => ({
-				...el,
-				styles: { ...wrapperStyles, ...el.styles },
-				attributes: { ...wrapperAttrs, ...el.attributes },
-			}));
-		}
+    if (result.type === 'fragment') {
+      const wrapperStyles = result.styles || {};
+      const wrapperAttrs = result.attributes || {};
+      return (result.content || []).map((el) => ({
+        ...el,
+        styles: { ...wrapperStyles, ...el.styles },
+        attributes: { ...wrapperAttrs, ...el.attributes },
+      }));
+    }
 
-		return extractAttributesToMetadata(result);
-	}
+    return extractAttributesToMetadata(result);
+  }
 
-	private _parseTableContainers(element: HTMLElement): TableRowElement[] {
-		const rows: TableRowElement[] = [];
-		const section = element.tagName.toLowerCase();
+  private _parseTableContainers(element: HTMLElement): TableRowElement[] {
+    const rows: TableRowElement[] = [];
+    const section = element.tagName.toLowerCase();
 
-		Array.from(element.children)
-			.filter((c): c is HTMLElement => c.tagName.toLowerCase() === "tr")
-			.forEach((tr) => {
-				const row = this._parseRow(tr);
-				row.metadata = {
-					...(row.metadata ?? {}),
-					section,
-				};
-				rows.push(row);
-			});
+    Array.from(element.children)
+      .filter((c): c is HTMLElement => c.tagName.toLowerCase() === 'tr')
+      .forEach((tr) => {
+        const row = this._parseRow(tr);
+        row.metadata = {
+          ...(row.metadata ?? {}),
+          section,
+        };
+        rows.push(row);
+      });
 
-		return rows;
-	}
+    return rows;
+  }
 
-	private _parseTable(
-		element: HTMLElement | ChildNode,
-		options: TagHandlerOptions = {},
-	): DocumentElement {
-		const rows: TableRowElement[] = [];
-		const content: DocumentElement[] = [];
+  private _parseTable(
+    element: HTMLElement | ChildNode,
+    options: TagHandlerOptions = {}
+  ): DocumentElement {
+    const rows: TableRowElement[] = [];
+    const content: DocumentElement[] = [];
 
-		const tableEl = element as HTMLElement;
+    const tableEl = element as HTMLElement;
 
-		// Fetch defaults
-		const defaultTableAttrs =
-			this._defaultAttributes.get(
-				tableEl.tagName.toLowerCase() as keyof HTMLElementTagNameMap,
-			) || {};
+    // Fetch defaults
+    const defaultTableAttrs =
+      this._defaultAttributes.get(
+        tableEl.tagName.toLowerCase() as keyof HTMLElementTagNameMap
+      ) || {};
 
-		const tableStyles = parseStyles(tableEl);
-		const tableAttrs = parseAttributes(tableEl);
+    const tableStyles = parseStyles(tableEl);
+    const tableAttrs = parseAttributes(tableEl);
 
-		// Map the deprecated HTML `border` attribute to CSS when no explicit
-		// border-style is already set via the `style` attribute.
-		// e.g. border="1" → borderStyle: 'solid', borderWidth: '1px'
-		// Per the HTML spec and browser behaviour, this also applies to all cells.
-		const borderAttr = tableAttrs["border"];
-		const borderPx = Number(borderAttr);
-		const tableBorderFromAttr =
-			borderAttr !== undefined &&
-			!tableStyles.borderStyle &&
-			!tableStyles.border &&
-			borderPx > 0;
+    // Map the deprecated HTML `border` attribute to CSS when no explicit
+    // border-style is already set via the `style` attribute.
+    // e.g. border="1" → borderStyle: 'solid', borderWidth: '1px'
+    // Per the HTML spec and browser behaviour, this also applies to all cells.
+    const borderAttr = tableAttrs['border'];
+    const borderPx = Number(borderAttr);
+    const tableBorderFromAttr =
+      borderAttr !== undefined &&
+      !tableStyles.borderStyle &&
+      !tableStyles.border &&
+      borderPx > 0;
 
-		if (tableBorderFromAttr) {
-			tableStyles.borderStyle = "solid";
-			tableStyles.borderWidth = `${borderPx}px`;
-		}
+    if (tableBorderFromAttr) {
+      tableStyles.borderStyle = 'solid';
+      tableStyles.borderWidth = `${borderPx}px`;
+    }
 
-		// Iterate *every* direct child of <table> in source order
-		Array.from(tableEl.childNodes).forEach((node) => {
-			if (node.nodeType !== 1) return; // skip text/comments
-			const el = node as HTMLElement;
-			const tag = el.tagName.toLowerCase();
+    // Iterate *every* direct child of <table> in source order
+    Array.from(tableEl.childNodes).forEach((node) => {
+      if (node.nodeType !== 1) return; // skip text/comments
+      const el = node as HTMLElement;
+      const tag = el.tagName.toLowerCase();
 
-			const result = this._parseElement(
-				el,
-				this._tagHandlers.get(tag) ?? this._defaultHandler,
-			);
+      const result = this._parseElement(
+        el,
+        this._tagHandlers.get(tag) ?? this._defaultHandler
+      );
 
-			if (Array.isArray(result)) {
-				rows.push(
-					...result.filter((c): c is TableRowElement => c.type === "table-row"),
-				);
-				content.push(
-					...result.filter((c): c is DocumentElement => c.type !== "table-row"),
-				);
-			} else {
-				if (result.type === "table-row") {
-					rows.push(result as TableRowElement);
-				}
-				if (result.type !== "table-row") {
-					content.push(result as DocumentElement);
-				}
-			}
-		});
+      if (Array.isArray(result)) {
+        rows.push(
+          ...result.filter((c): c is TableRowElement => c.type === 'table-row')
+        );
+        content.push(
+          ...result.filter((c): c is DocumentElement => c.type !== 'table-row')
+        );
+      } else {
+        if (result.type === 'table-row') {
+          rows.push(result as TableRowElement);
+        }
+        if (result.type !== 'table-row') {
+          content.push(result as DocumentElement);
+        }
+      }
+    });
 
-		// Propagate border attribute down to cells that don't have their own border.
-		if (tableBorderFromAttr) {
-			for (const row of rows) {
-				for (const cell of row.cells) {
-					if (!cell.styles?.borderStyle && !cell.styles?.border) {
-						cell.styles = {
-							...cell.styles,
-							borderStyle: "solid",
-							borderWidth: `${borderPx}px`,
-						};
-					}
-				}
-			}
-		}
-		return {
-			type: "table",
-			rows,
-			content: content.length > 0 ? content : undefined,
-			styles: {
-				...options.styles,
-				...tableStyles,
-			},
-			metadata: {
-				...options.metadata,
-				nested: tableEl.parentElement?.tagName.toLowerCase() === "td",
-			},
-			attributes: {
-				...defaultTableAttrs,
-				...options.attributes,
-				...tableAttrs,
-			},
-			scope: "table",
-		};
-	}
+    // Propagate border attribute down to cells that don't have their own border.
+    if (tableBorderFromAttr) {
+      for (const row of rows) {
+        for (const cell of row.cells) {
+          if (!cell.styles?.borderStyle && !cell.styles?.border) {
+            cell.styles = {
+              ...cell.styles,
+              borderStyle: 'solid',
+              borderWidth: `${borderPx}px`,
+            };
+          }
+        }
+      }
+    }
+    return {
+      type: 'table',
+      rows,
+      content: content.length > 0 ? content : undefined,
+      styles: {
+        ...options.styles,
+        ...tableStyles,
+      },
+      metadata: {
+        ...options.metadata,
+        nested: tableEl.parentElement?.tagName.toLowerCase() === 'td',
+      },
+      attributes: {
+        ...defaultTableAttrs,
+        ...options.attributes,
+        ...tableAttrs,
+      },
+      scope: 'table',
+    };
+  }
 
-	private _parseDocumentToElements(doc: Document): DocumentElement[] {
-		const content: DocumentElement[] = [];
+  private _parseDocumentToElements(doc: Document): DocumentElement[] {
+    const content: DocumentElement[] = [];
 
-		doc.body.childNodes.forEach((child) => {
-			const key = child.nodeName.toLowerCase();
-			const result = this._parseElement(
-				child,
-				this._tagHandlers.get(key) ?? this._defaultHandler,
-			);
-			// if (result) {
-			if (Array.isArray(result)) {
-				content.push(...result);
-			} else {
-				content.push(result);
-			}
-			// }
-		});
-		return content;
-	}
+    doc.body.childNodes.forEach((child) => {
+      const key = child.nodeName.toLowerCase();
+      const result = this._parseElement(
+        child,
+        this._tagHandlers.get(key) ?? this._defaultHandler
+      );
+      // if (result) {
+      if (Array.isArray(result)) {
+        content.push(...result);
+      } else {
+        content.push(result);
+      }
+      // }
+    });
+    return content;
+  }
 
-	private _defaultHandler(
-		element: HTMLElement | ChildNode,
-		options: TagHandlerOptions = {},
-	): DocumentElement {
-		if (element.nodeType === 3) {
-			return {
-				type: "text",
-				text: element.textContent || "",
-			};
-		}
-		const tag =
-			(element as HTMLElement).tagName?.toLowerCase() ||
-			(element as ChildNode).nodeName?.toLowerCase();
-		// Now just use options.text and options.content (children)
-		const text = (options.text ?? undefined) as string | undefined;
-		const children = (options.content ?? undefined) as
-			| DocumentElement[]
-			| ListItemElement[]
-			| undefined;
+  private _defaultHandler(
+    element: HTMLElement | ChildNode,
+    options: TagHandlerOptions = {}
+  ): DocumentElement {
+    if (element.nodeType === 3) {
+      return {
+        type: 'text',
+        text: element.textContent || '',
+      };
+    }
+    const tag =
+      (element as HTMLElement).tagName?.toLowerCase() ||
+      (element as ChildNode).nodeName?.toLowerCase();
+    // Now just use options.text and options.content (children)
+    const text = (options.text ?? undefined) as string | undefined;
+    const children = (options.content ?? undefined) as
+      | DocumentElement[]
+      | ListItemElement[]
+      | undefined;
 
-		switch (tag) {
-			case "p":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
-			case "div":
-				return { type: "fragment", text, content: children, ...options };
-			case "strong":
-			case "b":
-				return {
-					type: "text",
-					text,
-					content: children,
-					...options,
-					scope: "inline",
-				};
-			case "colgroup":
-				return {
-					type: "attribute",
-					name: "colgroup",
-					content: children,
-					scope: "inline",
-					...options,
-				};
-			case "col":
-				return {
-					type: "attribute",
-					name: "col",
-					content: children,
-					scope: "inline",
-					...options,
-				};
-			case "em":
-			case "i":
-			case "cite":
-			case "dfn":
-			case "var":
-				return {
-					type: "text",
-					text,
-					content: children,
-					scope: "inline",
-					...options,
-				};
-			case "small":
-				return {
-					type: "text",
-					text,
-					content: children,
-					scope: "inline",
-					...options,
-				};
+    switch (tag) {
+      case 'p':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
+      case 'div':
+        return { type: 'fragment', text, content: children, ...options };
+      case 'strong':
+      case 'b':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          ...options,
+          scope: 'inline',
+        };
+      case 'colgroup':
+        return {
+          type: 'attribute',
+          name: 'colgroup',
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
+      case 'col':
+        return {
+          type: 'attribute',
+          name: 'col',
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
+      case 'em':
+      case 'i':
+      case 'cite':
+      case 'dfn':
+      case 'var':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
+      case 'small':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
 
-			case "u":
-			case "ins":
-				return {
-					type: "text",
-					text,
-					content: children,
-					scope: "inline",
-					...options,
-				};
+      case 'u':
+      case 'ins':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
 
-			case "hr":
-				return { type: "line", ...options };
+      case 'hr':
+        return { type: 'line', ...options };
 
-			case "h1":
-			case "h2":
-			case "h3":
-				return {
-					type: "heading",
-					level: Number(tag.slice(1)),
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
+      case 'h1':
+      case 'h2':
+      case 'h3':
+        return {
+          type: 'heading',
+          level: Number(tag.slice(1)),
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
 
-			case "ul":
-			case "ol":
-				return {
-					type: "list",
-					listType: tag === "ol" ? "ordered" : "unordered",
-					content: children,
-					scope: "block",
-					level:
-						typeof options.metadata?.level === "number"
-							? options.metadata.level
-							: parseInt(options.metadata?.level as string) || 0,
-					...options,
-					metadata: {
-						...options.metadata,
-						level: options.metadata?.level ?? "0",
-					},
-				};
+      case 'ul':
+      case 'ol':
+        return {
+          type: 'list',
+          listType: tag === 'ol' ? 'ordered' : 'unordered',
+          content: children,
+          scope: 'block',
+          level:
+            typeof options.metadata?.level === 'number'
+              ? options.metadata.level
+              : parseInt(options.metadata?.level as string) || 0,
+          ...options,
+          metadata: {
+            ...options.metadata,
+            level: options.metadata?.level ?? '0',
+          },
+        };
 
-			case "li":
-				return {
-					type: "list-item",
-					text,
-					content: children,
-					level:
-						typeof options.metadata?.level === "number"
-							? options.metadata.level
-							: parseInt(options.metadata?.level as string) || 0,
-					scope: "block",
-					...options,
-				};
+      case 'li':
+        return {
+          type: 'list-item',
+          text,
+          content: children,
+          level:
+            typeof options.metadata?.level === 'number'
+              ? options.metadata.level
+              : parseInt(options.metadata?.level as string) || 0,
+          scope: 'block',
+          ...options,
+        };
 
-			case "header":
-				return { type: "header", text, content: children, ...options };
+      case 'header':
+        return { type: 'header', text, content: children, ...options };
 
-			case "address":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
+      case 'address':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
 
-			case "footer":
-				return { type: "footer", text, content: children, ...options };
+      case 'footer':
+        return { type: 'footer', text, content: children, ...options };
 
-			case "section":
-				if ((element as HTMLElement).classList.contains("page-break")) {
-					return { type: "page-break", ...options };
-				}
-				if ((element as HTMLElement).classList.contains("page")) {
-					return { type: "page", text, content: children, ...options };
-				}
-				return { type: "fragment", text, content: children, ...options };
+      case 'section':
+        if ((element as HTMLElement).classList.contains('page-break')) {
+          return { type: 'page-break', ...options };
+        }
+        if ((element as HTMLElement).classList.contains('page')) {
+          return { type: 'page', text, content: children, ...options };
+        }
+        return { type: 'fragment', text, content: children, ...options };
 
-			case "span":
-			case "a":
-			case "mark":
-			case "kbd":
-			case "samp":
-			case "s":
-			case "del":
-				return {
-					type: "text",
-					text,
-					content: children,
-					scope: "inline",
-					...options,
-				};
+      case 'span':
+      case 'a':
+      case 'mark':
+      case 'kbd':
+      case 'samp':
+      case 's':
+      case 'del':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
 
-			case "sup":
-				return {
-					type: "text",
-					text,
-					content: children,
-					scope: "inline",
-					...options,
-				};
+      case 'sup':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
 
-			case "sub":
-				return {
-					type: "text",
-					text,
-					content: children,
-					...options,
-					scope: "inline",
-				};
+      case 'sub':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          ...options,
+          scope: 'inline',
+        };
 
-			case "img":
-				return {
-					type: "image",
-					src: (element as HTMLImageElement).src,
-					scope: "inline", // default to inline, but can be changed to block depending on context
-					...options,
-				};
+      case 'img':
+        return {
+          type: 'image',
+          src: (element as HTMLImageElement).src,
+          scope: 'inline', // default to inline, but can be changed to block depending on context
+          ...options,
+        };
 
-			case "pre":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
+      case 'pre':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
 
-			case "code":
-				return {
-					type: "text",
-					text,
-					content: children,
-					scope: "inline",
-					...options,
-				};
+      case 'code':
+        return {
+          type: 'text',
+          text,
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
 
-			case "br":
-				return {
-					...options,
-					type: "text",
-					text: "",
-					metadata: { break: 1, ...options.metadata },
-					scope: "inline",
-				};
+      case 'br':
+        return {
+          ...options,
+          type: 'text',
+          text: '',
+          metadata: { break: 1, ...options.metadata },
+          scope: 'inline',
+        };
 
-			case "blockquote":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
+      case 'blockquote':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
 
-			// FIGURE and CAPTION now as paragraphs
-			case "figure":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
+      // FIGURE and CAPTION now as paragraphs
+      case 'figure':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
 
-			case "figcaption":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
-			case "caption":
-				return {
-					type: "attribute",
-					name: "caption",
-					text,
-					content: children,
-					scope: "inline",
-					...options,
-				};
-			// Description list container
-			case "dl":
-				return { type: "fragment", text, content: children, ...options };
-			// Description term
-			case "dt":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-					// default term style: bold
-					styles: { ...(options.styles || {}) },
-				};
-			// Description definition: indented
-			case "dd":
-				return {
-					type: "paragraph",
-					text,
-					content: children,
-					scope: "block",
-					...options,
-				};
+      case 'figcaption':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
+      case 'caption':
+        return {
+          type: 'attribute',
+          name: 'caption',
+          text,
+          content: children,
+          scope: 'inline',
+          ...options,
+        };
+      // Description list container
+      case 'dl':
+        return { type: 'fragment', text, content: children, ...options };
+      // Description term
+      case 'dt':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+          // default term style: bold
+          styles: { ...(options.styles || {}) },
+        };
+      // Description definition: indented
+      case 'dd':
+        return {
+          type: 'paragraph',
+          text,
+          content: children,
+          scope: 'block',
+          ...options,
+        };
 
-			default:
-				return { type: "custom", text, content: children, ...options };
-		}
-	}
+      default:
+        return { type: 'custom', text, content: children, ...options };
+    }
+  }
 }

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -373,11 +373,10 @@ export class Parser {
     if (tableBorderFromAttr) {
       for (const row of rows) {
         for (const cell of row.cells) {
-          if (!cell.styles?.borderStyle && !cell.styles?.border) {
+          if (!cell.styles?.border) {
             cell.styles = {
               ...cell.styles,
-              borderStyle: 'solid',
-              borderWidth: `${borderPx}px`,
+              border: '1px solid',
             };
           }
         }

--- a/packages/core/src/utils/html.serializer.ts
+++ b/packages/core/src/utils/html.serializer.ts
@@ -1,15 +1,16 @@
-import {
-  DocumentElement,
-  ImageElement,
-  TableElement,
-  TableRowElement,
-  TableCellElement,
-  HeadingElement,
-  ListElement,
-  IConverterDependencies,
-} from '../types';
 import type { IStylesheet } from '../styles/interfaces';
 import { createBaseStylesheet } from '../styles/stylesheet-seeding';
+import type {
+  DocumentElement,
+  HeadingElement,
+  IConverterDependencies,
+  ImageElement,
+  ListElement,
+  Styles,
+  TableCellElement,
+  TableElement,
+  TableRowElement,
+} from '../types';
 
 type HtmlSerializationStyles = IConverterDependencies['defaultStyles'];
 
@@ -97,6 +98,133 @@ const encodeText = (txt: string): string => {
 
 const encodeAttr = (val: string | number): string =>
   String(val).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+
+type BorderDirection = 'top' | 'right' | 'bottom' | 'left';
+
+const borderStyleTokens = [
+  'none',
+  'hidden',
+  'dotted',
+  'dashed',
+  'solid',
+  'double',
+  'groove',
+  'ridge',
+  'inset',
+  'outset',
+] as const;
+
+const extractBorderStyle = (
+  styles: Record<string, string | number>,
+  direction: BorderDirection
+): string | undefined => {
+  const directionalKey = `border${direction.charAt(0).toUpperCase()}${direction.slice(1)}Style`;
+  const directionalValue = styles[directionalKey];
+  if (typeof directionalValue === 'string') {
+    return directionalValue.trim().toLowerCase();
+  }
+
+  const borderStyleValue = styles.borderStyle;
+  if (typeof borderStyleValue === 'string') {
+    return borderStyleValue.trim().toLowerCase();
+  }
+
+  const shorthandBorderValue = styles.border;
+  if (typeof shorthandBorderValue !== 'string') {
+    return undefined;
+  }
+
+  const token = shorthandBorderValue
+    .split(/\s+/)
+    .map((part) => part.trim().toLowerCase())
+    .find((part): part is (typeof borderStyleTokens)[number] =>
+      (borderStyleTokens as readonly string[]).includes(part)
+    );
+
+  return token;
+};
+
+const isHiddenBorderStyle = (
+  styles: Record<string, string | number>,
+  direction: BorderDirection
+): boolean => {
+  const borderStyle = extractBorderStyle(styles, direction);
+  return borderStyle === 'hidden' || borderStyle === 'none';
+};
+
+const computeTablePerimeterOverrides = (
+  table: TableElement,
+  tableStyles: Record<string, string | number>
+): Map<TableCellElement, Styles> => {
+  const hideTop = isHiddenBorderStyle(tableStyles, 'top');
+  const hideRight = isHiddenBorderStyle(tableStyles, 'right');
+  const hideBottom = isHiddenBorderStyle(tableStyles, 'bottom');
+  const hideLeft = isHiddenBorderStyle(tableStyles, 'left');
+
+  if (!hideTop && !hideRight && !hideBottom && !hideLeft) {
+    return new Map();
+  }
+
+  let columnCount = 0;
+  for (const row of table.rows ?? []) {
+    let count = 0;
+    for (const cell of row.cells) {
+      count += cell.colspan ?? 1;
+    }
+    columnCount = Math.max(columnCount, count);
+  }
+
+  const rowCount = table.rows?.length ?? 0;
+  const occupied: boolean[][] = Array.from({ length: rowCount }, () =>
+    Array(Math.max(columnCount, 1)).fill(false)
+  );
+  const overrides = new Map<TableCellElement, Styles>();
+
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    const row = table.rows[rowIndex];
+    if (!row) continue;
+
+    let columnIndex = 0;
+    for (const cell of row.cells) {
+      while (occupied[rowIndex]?.[columnIndex]) {
+        columnIndex++;
+      }
+
+      const colSpan = cell.colspan ?? 1;
+      const rowSpan = cell.rowspan ?? 1;
+
+      for (let r = rowIndex; r < Math.min(rowIndex + rowSpan, rowCount); r++) {
+        for (let c = columnIndex; c < columnIndex + colSpan; c++) {
+          if (occupied[r]) {
+            occupied[r]![c] = true;
+          }
+        }
+      }
+
+      const cellOverrides: Styles = {};
+      if (hideTop && rowIndex === 0) {
+        cellOverrides.borderTopStyle = 'hidden';
+      }
+      if (hideLeft && columnIndex === 0) {
+        cellOverrides.borderLeftStyle = 'hidden';
+      }
+      if (hideBottom && rowIndex + rowSpan >= rowCount) {
+        cellOverrides.borderBottomStyle = 'hidden';
+      }
+      if (hideRight && columnIndex + colSpan >= columnCount) {
+        cellOverrides.borderRightStyle = 'hidden';
+      }
+
+      if (Object.keys(cellOverrides).length > 0) {
+        overrides.set(cell, cellOverrides);
+      }
+
+      columnIndex += colSpan;
+    }
+  }
+
+  return overrides;
+};
 
 function filterStyles(tag: string, styles: Record<string, string | number>) {
   const filtered: Record<string, string | number> = {};
@@ -261,6 +389,10 @@ function elementToHtml(
 
   if (el.type === 'table') {
     const table = el as TableElement;
+    const perimeterOverrides = computeTablePerimeterOverrides(
+      table,
+      mergedStyles
+    );
     const theadRows: string[] = [];
     const tbodyRows: string[] = [];
 
@@ -274,7 +406,9 @@ function elementToHtml(
           return c.metadata?.tagName === 'th';
         });
       const cellsHtml = row.cells
-        .map((c) => cellToHtml(c, defaults, stylesheet))
+        .map((c) =>
+          cellToHtml(c, defaults, stylesheet, perimeterOverrides.get(c))
+        )
         .join('\n');
       const rowHtml = `<tr>\n${cellsHtml}\n</tr>`;
 
@@ -319,7 +453,8 @@ function elementToHtml(
 function cellToHtml(
   cell: TableCellElement,
   defaults: HtmlSerializationStyles = {},
-  stylesheet: IStylesheet = createBaseStylesheet()
+  stylesheet: IStylesheet = createBaseStylesheet(),
+  styleOverrides: Styles = {}
 ): string {
   const tag = cell.metadata?.tagName === 'th' ? 'th' : 'td';
   // basic attrs
@@ -331,6 +466,7 @@ function cellToHtml(
   const merged = {
     ...defaults[cell.type],
     ...stylesheet.getComputedStyles(cell, undefined),
+    ...styleOverrides,
   };
   if (Object.keys(merged).length) {
     const styleEntries = Object.entries(filterStyles(tag, merged)).map(

--- a/packages/core/src/utils/html.serializer.ts
+++ b/packages/core/src/utils/html.serializer.ts
@@ -1,16 +1,15 @@
-import type { IStylesheet } from '../styles/interfaces';
-import { createBaseStylesheet } from '../styles/stylesheet-seeding';
-import type {
+import {
   DocumentElement,
-  HeadingElement,
-  IConverterDependencies,
   ImageElement,
-  ListElement,
-  Styles,
-  TableCellElement,
   TableElement,
   TableRowElement,
+  TableCellElement,
+  HeadingElement,
+  ListElement,
+  IConverterDependencies,
 } from '../types';
+import type { IStylesheet } from '../styles/interfaces';
+import { createBaseStylesheet } from '../styles/stylesheet-seeding';
 
 type HtmlSerializationStyles = IConverterDependencies['defaultStyles'];
 
@@ -98,133 +97,6 @@ const encodeText = (txt: string): string => {
 
 const encodeAttr = (val: string | number): string =>
   String(val).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-
-type BorderDirection = 'top' | 'right' | 'bottom' | 'left';
-
-const borderStyleTokens = [
-  'none',
-  'hidden',
-  'dotted',
-  'dashed',
-  'solid',
-  'double',
-  'groove',
-  'ridge',
-  'inset',
-  'outset',
-] as const;
-
-const extractBorderStyle = (
-  styles: Record<string, string | number>,
-  direction: BorderDirection
-): string | undefined => {
-  const directionalKey = `border${direction.charAt(0).toUpperCase()}${direction.slice(1)}Style`;
-  const directionalValue = styles[directionalKey];
-  if (typeof directionalValue === 'string') {
-    return directionalValue.trim().toLowerCase();
-  }
-
-  const borderStyleValue = styles.borderStyle;
-  if (typeof borderStyleValue === 'string') {
-    return borderStyleValue.trim().toLowerCase();
-  }
-
-  const shorthandBorderValue = styles.border;
-  if (typeof shorthandBorderValue !== 'string') {
-    return undefined;
-  }
-
-  const token = shorthandBorderValue
-    .split(/\s+/)
-    .map((part) => part.trim().toLowerCase())
-    .find((part): part is (typeof borderStyleTokens)[number] =>
-      (borderStyleTokens as readonly string[]).includes(part)
-    );
-
-  return token;
-};
-
-const isHiddenBorderStyle = (
-  styles: Record<string, string | number>,
-  direction: BorderDirection
-): boolean => {
-  const borderStyle = extractBorderStyle(styles, direction);
-  return borderStyle === 'hidden' || borderStyle === 'none';
-};
-
-const computeTablePerimeterOverrides = (
-  table: TableElement,
-  tableStyles: Record<string, string | number>
-): Map<TableCellElement, Styles> => {
-  const hideTop = isHiddenBorderStyle(tableStyles, 'top');
-  const hideRight = isHiddenBorderStyle(tableStyles, 'right');
-  const hideBottom = isHiddenBorderStyle(tableStyles, 'bottom');
-  const hideLeft = isHiddenBorderStyle(tableStyles, 'left');
-
-  if (!hideTop && !hideRight && !hideBottom && !hideLeft) {
-    return new Map();
-  }
-
-  let columnCount = 0;
-  for (const row of table.rows ?? []) {
-    let count = 0;
-    for (const cell of row.cells) {
-      count += cell.colspan ?? 1;
-    }
-    columnCount = Math.max(columnCount, count);
-  }
-
-  const rowCount = table.rows?.length ?? 0;
-  const occupied: boolean[][] = Array.from({ length: rowCount }, () =>
-    Array(Math.max(columnCount, 1)).fill(false)
-  );
-  const overrides = new Map<TableCellElement, Styles>();
-
-  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-    const row = table.rows[rowIndex];
-    if (!row) continue;
-
-    let columnIndex = 0;
-    for (const cell of row.cells) {
-      while (occupied[rowIndex]?.[columnIndex]) {
-        columnIndex++;
-      }
-
-      const colSpan = cell.colspan ?? 1;
-      const rowSpan = cell.rowspan ?? 1;
-
-      for (let r = rowIndex; r < Math.min(rowIndex + rowSpan, rowCount); r++) {
-        for (let c = columnIndex; c < columnIndex + colSpan; c++) {
-          if (occupied[r]) {
-            occupied[r]![c] = true;
-          }
-        }
-      }
-
-      const cellOverrides: Styles = {};
-      if (hideTop && rowIndex === 0) {
-        cellOverrides.borderTopStyle = 'hidden';
-      }
-      if (hideLeft && columnIndex === 0) {
-        cellOverrides.borderLeftStyle = 'hidden';
-      }
-      if (hideBottom && rowIndex + rowSpan >= rowCount) {
-        cellOverrides.borderBottomStyle = 'hidden';
-      }
-      if (hideRight && columnIndex + colSpan >= columnCount) {
-        cellOverrides.borderRightStyle = 'hidden';
-      }
-
-      if (Object.keys(cellOverrides).length > 0) {
-        overrides.set(cell, cellOverrides);
-      }
-
-      columnIndex += colSpan;
-    }
-  }
-
-  return overrides;
-};
 
 function filterStyles(tag: string, styles: Record<string, string | number>) {
   const filtered: Record<string, string | number> = {};
@@ -389,10 +261,6 @@ function elementToHtml(
 
   if (el.type === 'table') {
     const table = el as TableElement;
-    const perimeterOverrides = computeTablePerimeterOverrides(
-      table,
-      mergedStyles
-    );
     const theadRows: string[] = [];
     const tbodyRows: string[] = [];
 
@@ -406,9 +274,7 @@ function elementToHtml(
           return c.metadata?.tagName === 'th';
         });
       const cellsHtml = row.cells
-        .map((c) =>
-          cellToHtml(c, defaults, stylesheet, perimeterOverrides.get(c))
-        )
+        .map((c) => cellToHtml(c, defaults, stylesheet))
         .join('\n');
       const rowHtml = `<tr>\n${cellsHtml}\n</tr>`;
 
@@ -453,8 +319,7 @@ function elementToHtml(
 function cellToHtml(
   cell: TableCellElement,
   defaults: HtmlSerializationStyles = {},
-  stylesheet: IStylesheet = createBaseStylesheet(),
-  styleOverrides: Styles = {}
+  stylesheet: IStylesheet = createBaseStylesheet()
 ): string {
   const tag = cell.metadata?.tagName === 'th' ? 'th' : 'td';
   // basic attrs
@@ -466,7 +331,6 @@ function cellToHtml(
   const merged = {
     ...defaults[cell.type],
     ...stylesheet.getComputedStyles(cell, undefined),
-    ...styleOverrides,
   };
   if (Object.keys(merged).length) {
     const styleEntries = Object.entries(filterStyles(tag, merged)).map(


### PR DESCRIPTION
This PR fixes support for `border-style: hidden` on tables and table cells when exported to DocX and PDF, plus adds regression tests. 