### PR TITLE
feat(docx): background color on <mark> becomes highlight if css matches

### DIFF
--- a/packages/adapters/docx/src/docx-style-mapper.ts
+++ b/packages/adapters/docx/src/docx-style-mapper.ts
@@ -18,6 +18,7 @@ import {
   IImageOptions,
   ITableRowOptions,
   ISpacingProperties,
+  IRunOptions,
 } from 'docx';
 import {
   twipsToEighthsOfPoint,
@@ -228,6 +229,23 @@ export class DocxStyleMapper {
       backgroundColor: (v, el) => {
         if (el.type === 'table') return {};
         // strip “#” and turn CSS names → hex
+
+        if (el.metadata?.tag === 'mark') {
+          let hightlightColor: IRunOptions['highlight'] | null = null;
+          switch (v.trim().toLowerCase()) {
+            case '#ffff00':
+            case 'yellow':
+              hightlightColor = 'yellow';
+              break;
+            // TODO: add the other available hightlight colors
+          }
+          if (hightlightColor) {
+            return {
+              highlight: hightlightColor,
+            } satisfies IRunOptions;
+          }
+        }
+
         const fill = colorConversion(v);
         return {
           shading: {
@@ -235,7 +253,7 @@ export class DocxStyleMapper {
             fill, // e.g. "F9F9F9"
             color: 'auto', // text color fallback
           },
-        };
+        } satisfies IRunOptions;
       },
 
       // Font size


### PR DESCRIPTION
This is a draft for setting highlight in docx based on `<mark>` elements.

I think it is reasonable that `<mark>` elements becomes highlight in docx since that is the actual semantic meaning of a `<mark>` element.

One problem though: doc only supports a few colors (or maybe only docx.js?).

One consideration. The `colornames` package is already used in this project, we could use it as for this as well to normalize the values and simplify the switch.

TODO:

- [ ] Tests
- [ ] The other colors